### PR TITLE
Hero buttons fix for desktopSmall

### DIFF
--- a/src/components/hero/hero.module.scss
+++ b/src/components/hero/hero.module.scss
@@ -16,10 +16,6 @@
 	}
 
 	@include from($desktopSmall) {
-		grid-template-columns: repeat(1, minmax(0, 1fr));
-	}
-
-	@include from($desktopLarge) {
 		grid-template-columns: repeat(2, minmax(0, 1fr));
 	}
 }


### PR DESCRIPTION
This makes it so the hero buttons display in a row rather than a column after the 1280px requirement is met. Previously this only happened when the display was larger than 1920px.