### PR TITLE
Open Collective ad `z-index` fix. 

### DIFF
--- a/src/styles/markdown/in-content-ads.scss
+++ b/src/styles/markdown/in-content-ads.scss
@@ -57,6 +57,7 @@
 
 .in-content-image {
 	height: 152px;
+	z-index: 1;
 
 	@include from($tabletSmall) {
 		min-height: 152px;


### PR DESCRIPTION
Makes it so the inner background does not overlap the sticker illustration