### PR TITLE
Improve `noindex` usage for collections, posts, robots.txt

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -319,6 +319,11 @@ We support the following properties on a post:
   - Required if the post is a cross-post
 - `noindex`: Should the article be hidden from the site's list view, `sitemap`, and search?
   - Useful for draft or archived content
+- `upToDateSlug`: The latest published version of the article
+- `version`: The version of the article
+  - IE: `v1`, `v3.5`, etc
+  - Useful when combined with `upToDateSlug` and `noindex`
+
 
 ### Collection Frontmatter
 
@@ -348,3 +353,9 @@ We support the following properties on a post:
   - Must be an array of `{text: string, url: string}`
 - `chapterList`: A list of extra chapters to include in addition to the auto-discovered ones
   - Must be an array of `{title: string;description: string;order: string;}`
+- `noindex`: Should the collection be hidden from the site's list view, `sitemap`, and search?
+  - Useful for draft or archived content
+- `upToDateSlug`: The latest published version of the collection
+- `version`: The version of the collection
+  - IE: `v1`, `v3.5`, etc
+  - Useful when combined with `upToDateSlug` and `noindex`

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -10,7 +10,7 @@ import symlink from "symlink-dir";
 import * as path from "path";
 import { languages } from "./src/constants/index";
 import { fileToOpenGraphConverter } from "./src/utils/translations";
-import { posts } from "./src/utils/data";
+import { posts, collections } from "./src/utils/data";
 import { SUPPORTED_IMAGE_SIZES } from "./src/utils/get-picture";
 import { astroIntegrationCopyGenerated } from "./src/utils/markdown/astro-integration-copy-generated";
 
@@ -46,16 +46,18 @@ export default defineConfig({
 				),
 			},
 			filter(page) {
-				// return true, unless last part of the URL ends with "_noindex"
-				// in which case it should not be in the sitemap
+				// return true, unless the page is a blog post with `noindex` or `originalLink` set
+				// Or if it's a collection with `noindex` set
 				const lastPartOfSlug = page
 					.split("/")
 					.filter((part) => !!part.length)
 					.at(-1);
 
-				if (lastPartOfSlug!.endsWith("_noindex")) return false;
 				const relatedPost = posts.get(lastPartOfSlug!);
 				if (relatedPost && relatedPost[0]?.originalLink) return false;
+				if (relatedPost && relatedPost[0]?.noindex) return false;
+				const relatedCollection = collections.get(lastPartOfSlug!);
+				if (relatedCollection && relatedCollection[0]?.noindex) return false;
 				return true;
 			},
 			serialize({ url, ...rest }) {

--- a/src/pages/[...locale]/posts/[postid].astro
+++ b/src/pages/[...locale]/posts/[postid].astro
@@ -14,11 +14,7 @@ export async function getStaticPaths() {
 		return {
 			params: {
 				locale: post.locale !== "en" ? post.locale : undefined,
-				postid:
-					post.slug +
-					// "_noindex" appended here to filter affected URLs
-					// from the sitemap
-					(post.noindex ? "_noindex" : ""),
+				postid: post.slug,
 			},
 			props: {
 				slug: post.slug,

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -1,11 +1,39 @@
 import { buildMode, siteUrl } from "constants/site-config";
+import { getAllPosts, getAllCollections } from "utils/api";
+import { PostInfo } from "types/PostInfo";
+import { CollectionInfo } from "types/CollectionInfo";
+
+const noIndexPosts = getAllPosts().filter((post) => post.noindex);
+const noIndexCollection = getAllCollections().filter(
+	(collection) => collection.noindex && collection.pageLayout !== "none",
+);
+
+function buildPostUrl(post: PostInfo) {
+	return `${post.locale === "en" ? "" : "/" + post.locale}/posts/${post.slug}`;
+}
+
+function buildCollectionUrl(collection: CollectionInfo) {
+	return `${collection.locale === "en" ? "" : "/" + collection.locale}/collections/${collection.slug}`;
+}
 
 export const GET = () => {
 	let body = "";
 	if (buildMode === "production") {
+		let omitPosts = `\n# No index posts\n`;
+		for (const post of noIndexPosts) {
+			omitPosts += `Disallow: ${buildPostUrl(post)}\n`;
+		}
+
+		let omitCollections = `# No index collections\n`;
+		for (const collection of noIndexCollection) {
+			omitCollections += `Disallow: ${buildCollectionUrl(collection)}\n`;
+		}
+
 		body = `
 # *
 User-agent: *
+${noIndexPosts.length ? omitPosts : ""}
+${noIndexCollection.length ? omitCollections : ""}
 Allow: /
 
 # Host

--- a/src/types/CollectionInfo.ts
+++ b/src/types/CollectionInfo.ts
@@ -11,6 +11,9 @@ export interface RawCollectionInfo {
 	customChaptersText?: string;
 	tags?: string[];
 	published: string;
+	noindex?: boolean;
+	version?: string;
+	upToDateSlug?: string;
 	buttons?: Array<{ text: string; url: string }>;
 	chapterList?: Array<{
 		title: string;

--- a/src/types/PostInfo.ts
+++ b/src/types/PostInfo.ts
@@ -12,6 +12,8 @@ export interface RawPostInfo {
 	order?: number;
 	originalLink?: string;
 	noindex?: boolean;
+	version?: string;
+	upToDateSlug?: string;
 }
 
 export interface PostInfo extends RawPostInfo {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -90,6 +90,7 @@ export function getCollectionsByLang(language: Languages): CollectionInfo[] {
 	return [...collections.values()]
 		.map((locales) => locales.find((p) => p.locale === language) || locales[0])
 		.filter(isDefined)
+		.filter((p) => !p.noindex)
 		.sort(compareByPublished);
 }
 
@@ -101,6 +102,7 @@ export function getCollectionsByPerson(
 		.map((locales) => locales.find((p) => p.locale === language) || locales[0])
 		.filter(isDefined)
 		.filter((c) => c.authors.includes(personId))
+		.filter((p) => !p.noindex)
 		.sort(compareByPublished);
 }
 

--- a/src/views/blog-post/series/series-toc.astro
+++ b/src/views/blog-post/series/series-toc.astro
@@ -39,7 +39,7 @@ const showMoreText = translate(
 					{collection ? (
 						<a
 							class={`text-style-headline-4 ${styles.articleTitle}`}
-							href={`/collections/${collection.slug}`}
+							href={`/collections/${collection.upToDateSlug ?? collection.slug}`}
 						>
 							{collection.title}
 						</a>


### PR DESCRIPTION
This PR:

- Adds some new frontmatter properties on posts and collections to attribute differently versioned (but otherwise similar contents of) posts and collections to one another
- Documents those new properties
- Adds support for `noindex` collections
- Makes it so that URLs don't add `_noindex` to the slug of `noindex` posts
- Add `noindex` support to `robots.txt` for prod