### PR TITLE
fix: devmode now works with opening idea and vscode files

### DIFF
--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -9,7 +9,7 @@ import {
 } from "types/index";
 import * as fs from "fs/promises";
 import path, { join } from "path";
-import { isNotJunk } from "junk";
+import { isNotJunk as baseIsNotJunk } from "junk";
 import { getImageSize } from "../utils/get-image-size";
 import { resolvePath } from "./url-paths";
 import matter from "gray-matter";
@@ -26,6 +26,11 @@ import aboutRaw from "../../content/data/about.json";
 import rolesRaw from "../../content/data/roles.json";
 import licensesRaw from "../../content/data/licenses.json";
 import tagsRaw from "../../content/data/tags.json";
+
+function isNotJunk(name: string): boolean {
+	// Ignore VSCode and JetBrains project files
+	return baseIsNotJunk(name) && name !== ".idea" && name !== ".vscode";
+}
 
 export const contentDirectory = join(process.cwd(), "content");
 


### PR DESCRIPTION
The NPM `junk` folder seemingly wasn't filtering out `.idea` or `.vscode` files anymore, so I added them to our filters.

This makes it so that when one opens a subfolder in an IDE it doesn't break dev mode. 