### PR TITLE
Refer to File.vue in Vue example

### DIFF
--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/index.md
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/index.md
@@ -325,7 +325,7 @@ bootstrapApplication(FileComponent);
 
 ## Vue
 
-Because Vue's components all live within dedicated `.vue` SFCs, we have to use two distinct files to render a basic Vue app. We start with our `App.vue` component:
+Because Vue's components all live within dedicated `.vue` SFCs, we have to use two distinct files to render a basic Vue app. We start with our `File.vue` component:
 
 ```vue
 <!-- File.vue -->


### PR DESCRIPTION
As discussed on discord, the example in the Rendering the App section should refer to File.vue instead of App.vue.

https://discord.com/channels/609050358949347368/1094715906577403905/1310404508043444295