### PR TITLE
Add overflow-wrap:break-word to enforce text wrapping

### DIFF
--- a/src/styles/text-styles.scss
+++ b/src/styles/text-styles.scss
@@ -37,6 +37,12 @@
 
 :root {
 	font-family: var(--pfp-font-family);
+
+	// Prevent long text from overflowing if there are no acceptable break points
+	// (this is necessary as Chrome/etc have different text wrap behavior)
+	// https://github.com/playfulprogramming/playfulprogramming/issues/1213
+	// https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap
+	overflow-wrap: break-word;
 }
 
 :where(.text-style-headline-1) {


### PR DESCRIPTION
Fixes #1213

Used [`overflow-wrap: break-word;`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap) in place of `anywhere` as it does not affect content size calculation:
> soft wrap opportunities introduced by the word break are NOT considered when calculating min-content intrinsic sizes.