### PR TITLE
chore: migrate from SSG to SSR

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
 		},
 		devImageService: "sharp",
 	}),
+	output: "server",
 	integrations: [
 		icon(),
 		preact({ compat: true }),

--- a/src/pages/[...locale]/about.astro
+++ b/src/pages/[...locale]/about.astro
@@ -8,35 +8,28 @@ import { join } from "path";
 import { contentDirectory } from "utils/data";
 import { Languages } from "types/index";
 
-export async function getStaticPaths() {
-	const files = (await fs.readdir(join(contentDirectory, "site")))
-		.filter((filename) => filename.startsWith("about-us"))
-		.map((filename) => ({
-			file: join(contentDirectory, "site", filename),
-			locale: getLanguageFromFilename(filename),
-		}));
-
-	return files.map((data) => {
-		return {
-			params: {
-				locale: data.locale !== "en" ? data.locale : undefined,
-			},
-			props: {
-				file: data.file,
-				locales: files.map((d) => d.locale),
-				locale: data.locale,
-			},
-		};
-	});
-}
-
-interface Props {
-	file: string;
-	locales: Languages[];
+const params = Astro.params as {
 	locale: Languages;
+};
+
+const locale = params.locale && params.locale !== "en" ? params.locale : "en";
+
+const siteFiles = await fs.readdir(join(contentDirectory, "site"));
+
+let locales = [] as Languages[];
+let file = null;
+
+for (const siteFileName of siteFiles) {
+	if (!siteFileName.startsWith("about-us")) continue;
+	const fileLocale = getLanguageFromFilename(siteFileName);
+	locales.push(fileLocale);
+	if (fileLocale !== locale) continue;
+	file = join(contentDirectory, "site", siteFileName);
 }
 
-const { file, locales, locale } = Astro.props as Props;
+if (!file) {
+	return Astro.redirect("/404");
+}
 ---
 
 <Document>

--- a/src/pages/[...locale]/collections/[slug].astro
+++ b/src/pages/[...locale]/collections/[slug].astro
@@ -10,28 +10,6 @@ import { translate } from "utils/translations";
 import { Languages } from "types/index";
 import { getMarkdownHtml } from "utils/markdown";
 
-export async function getStaticPaths() {
-	const collections = api.getAllCollections();
-
-	return collections
-		.filter((collection) => collection.pageLayout !== "none")
-		.map((collection) => {
-			return {
-				params: {
-					locale: collection.locale !== "en" ? collection.locale : undefined,
-					slug: collection.slug,
-				},
-				props: {},
-			};
-		});
-}
-
-interface CollectionProps {
-	Content: MarkdownInstance<never>["Content"];
-}
-
-const { Content } = Astro.props as CollectionProps;
-
 const params = Astro.params as {
 	locale?: Languages;
 	slug: string;
@@ -39,6 +17,11 @@ const params = Astro.params as {
 
 const locale = params.locale || "en";
 const collection = api.getCollectionBySlug(params.slug, locale)!;
+
+if (!collection || collection.pageLayout === "none") {
+	return Astro.redirect("/404");
+}
+
 const collectionPosts = api.getPostsByCollection(params.slug, locale);
 const authors = collection.authors.map(
 	(authorId) => api.getPersonById(authorId, locale)!,

--- a/src/pages/[...locale]/posts/[postid].astro
+++ b/src/pages/[...locale]/posts/[postid].astro
@@ -7,33 +7,20 @@ import * as api from "utils/api";
 import { getMarkdownHtml } from "utils/markdown";
 import { isDefined } from "utils/is-defined";
 
-export async function getStaticPaths() {
-	const posts = api.getAllPosts();
-
-	return posts.map((post) => {
-		return {
-			params: {
-				locale: post.locale !== "en" ? post.locale : undefined,
-				postid: post.slug,
-			},
-			props: {
-				slug: post.slug,
-			},
-		};
-	});
-}
-
-const { slug } = Astro.props as {
-	slug: string;
-};
-
 const params = Astro.params as {
 	locale: Languages;
 	postid: string;
 };
 
+const slug = params.postid;
+
 const locale = params.locale ?? "en";
 const post = api.getPostBySlug(slug, locale)!;
+
+if (!post) {
+	return Astro.redirect("/404");
+}
+
 const authors = post.authors
 	.map((personId) => api.getPersonById(personId, locale))
 	.filter(isDefined);

--- a/src/pages/page/[page].astro
+++ b/src/pages/page/[page].astro
@@ -2,29 +2,32 @@
 import Document from "../../layouts/document.astro";
 import PageView from "src/views/explore/page.astro";
 import { getPostsByLang } from "utils/api";
-import { PostInfo } from "types/index";
 import SEO from "components/seo/seo.astro";
 import type { Page } from "astro";
-import { GetStaticPaths } from "astro";
 
-export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
-	const postsToDisplay = getPostsByLang("en");
+const posts = getPostsByLang("en");
 
-	return paginate(postsToDisplay, { pageSize: 8 });
-};
+const { page } = Astro.params as { page: string };
 
-const { page } = Astro.props as { page: Page<PostInfo> };
+const currentPage = parseInt(page, 10);
 
-const pageIndex = page.currentPage;
+const postsPerPage = 8;
 
-const SEOTitle = `Post page ${pageIndex}`;
+const data = posts.slice(
+	(currentPage - 1) * postsPerPage,
+	currentPage * postsPerPage,
+);
 
-const SEODescription = `Browse all posts on Playful Programming, page ${pageIndex}`;
+const lastPage = Math.ceil(posts.length / postsPerPage);
+
+const SEOTitle = `Post page ${currentPage}`;
+
+const SEODescription = `Browse all posts on Playful Programming, page ${currentPage}`;
 ---
 
 <Document>
 	<SEO slot="head" title={SEOTitle} description={SEODescription} />
 	<main class="container">
-		<PageView posts={page.data} page={page} />
+		<PageView posts={data} currentPage={currentPage} lastPage={lastPage} />
 	</main>
 </Document>

--- a/src/pages/people/[personid]/index.astro
+++ b/src/pages/people/[personid]/index.astro
@@ -5,15 +5,15 @@ import PersonPage from "src/views/person/person-page.astro";
 import { Languages } from "types/index";
 import * as api from "utils/api";
 
-export async function getStaticPaths() {
-	const people = api.getPeopleByLang("en");
-	return people.map((person) => ({ params: { personid: person.id } }));
-}
-
 const params = Astro.params as { personid: string };
 
 const locale: Languages = "en";
 const person = api.getPersonById(params.personid, locale)!;
+
+if (!person) {
+	return Astro.redirect("/404");
+}
+
 const posts = api.getPostsByPerson(person.id, locale);
 ---
 

--- a/src/views/explore/page.astro
+++ b/src/views/explore/page.astro
@@ -8,11 +8,12 @@ import { isDefined } from "utils/is-defined";
 
 export interface PageProps {
 	posts: PostInfo[];
-	page: Pick<Page, "currentPage" | "lastPage">;
+	currentPage: number;
+	lastPage: number;
 	locale: Languages;
 }
 
-const { posts, page, locale } = Astro.props as PageProps;
+const { posts, currentPage, lastPage, locale } = Astro.props as PageProps;
 
 const postAuthors = new Map(
 	[...new Set(posts.flatMap((p) => p.authors))]
@@ -35,7 +36,7 @@ const postAuthors = new Map(
 	/* We shouldn't pass the whole "page" object here, as this generates a huge JSON attribute for hydration */
 }
 <Pagination
-	page={{ currentPage: page.currentPage, lastPage: page.lastPage }}
+	page={{ currentPage: currentPage, lastPage: lastPage }}
 	rootURL="/page/"
 	client:load
 />


### PR DESCRIPTION
This PR implements SSR rather than SSG, including 404 redirects when data is not found, etc

While this code works 100%, we're marking it WIP because:

1) This code does not execute on Vercel ("serverless fn is too large" error)
2) Because our `api.ts` file does not cache most things, it's much more computationally expensive than it needs to be right now
3) It doesn't provide our readers value yet