### PR TITLE
Small header design fixes

### DIFF
--- a/src/views/base/navigation/header.astro
+++ b/src/views/base/navigation/header.astro
@@ -111,13 +111,9 @@ const props = Astro.props as {
 				{
 					isHome ? (
 						<DarkLightButton variant="large" class={style.themeToggleLarge} />
-					) : (
-						<DarkLightButton
-							variant="iconOnly"
-							class={style.themeToggleSmall}
-						/>
-					)
+					) : undefined
 				}
+				<DarkLightButton variant="iconOnly" class={style.themeToggleSmall} />
 			</div>
 		</nav>
 	</div>

--- a/src/views/base/navigation/header.astro
+++ b/src/views/base/navigation/header.astro
@@ -111,9 +111,13 @@ const props = Astro.props as {
 				{
 					isHome ? (
 						<DarkLightButton variant="large" class={style.themeToggleLarge} />
-					) : undefined
+					) : (
+						<DarkLightButton
+							variant="iconOnly"
+							class={style.themeToggleSmall}
+						/>
+					)
 				}
-				<DarkLightButton variant="iconOnly" class={style.themeToggleSmall} />
 			</div>
 		</nav>
 	</div>

--- a/src/views/base/navigation/header.module.scss
+++ b/src/views/base/navigation/header.module.scss
@@ -25,13 +25,12 @@ header {
 	border-bottom: 1px solid transparent;
 	&[data-sticky="pinned"] {
 		border-bottom: 1px solid var(--background_disabled);
+		background-color: var(--background_primary);
 	}
 
 	top: -0.1px;
 	position: sticky;
 	z-index: 2;
-	background-color: var(--background_primary);
-	@include transition(background-color);
 }
 
 .header {

--- a/src/views/base/navigation/header.module.scss
+++ b/src/views/base/navigation/header.module.scss
@@ -152,7 +152,7 @@ header {
 			display: flex;
 		}
 
-		.themeToggleLarge + .themeToggleSmall {
+		.themeToggleLarge ~ .themeToggleSmall {
 			display: none;
 		}
 	}


### PR DESCRIPTION
Fixed clipping of the CSS icon in the banner by making the header transparent until a scroll is detected. Removed the transition duration as a 1px divider isn't gonna make or break anything.

Couldn't find any conflicting pages with this change.

Also fixed - in my particular way - the doubled theme buttons on the homepage.