### PR TITLE
Fix inaccurate tag counts on search when no query is entered

### DIFF
--- a/src/pages/searchFilters.json.ts
+++ b/src/pages/searchFilters.json.ts
@@ -7,7 +7,7 @@ export const GET = async () => {
 		.getPeopleByLang("en")
 		.filter((person) => person.totalPostCount > 0);
 
-	const posts = api.getAllPosts();
+	const posts = api.getPostsByLang("en");
 
 	const tags = Object.entries(tagsObj).map(([tag, value]) => {
 		return {


### PR DESCRIPTION
Fixes #1253 

`getAllPosts()` was returning nested/extra posts in collections, including an additional copy of every FFG post.

In comparison, the searchIndex endpoint uses `getPostsByLang("en")`, which does not.