### PR TITLE
Fix collection card sizing on small viewports

### DIFF
--- a/src/components/collection-card/collection-card.module.scss
+++ b/src/components/collection-card/collection-card.module.scss
@@ -46,6 +46,7 @@
 	display: flex;
 	flex-shrink: 0;
 	overflow: hidden;
+	align-self: flex-start;
 
 	&:where(img),
 	& img {
@@ -89,6 +90,10 @@
 	margin-top: var(--collection-card_author_padding-top);
 	margin-right: var(--collection-card_author_padding-right);
 	margin-left: var(--collection-card_author_padding-left);
+
+	&> :global(.button) {
+		align-self: flex-end;
+	}
 }
 
 .authorList {

--- a/src/components/collection-card/collection-card.tsx
+++ b/src/components/collection-card/collection-card.tsx
@@ -24,7 +24,7 @@ export const CollectionCard = ({
 	const coverImgWidth = Math.max(160, Math.ceil(240 * coverImgAspectRatio));
 
 	return (
-		<div className={style.container}>
+		<li className={style.container}>
 			<div className={style.topRow}>
 				<UUPicture
 					src={collection.coverImgMeta.relativeServerPath}
@@ -79,6 +79,6 @@ export const CollectionCard = ({
 					)}
 				</Button>
 			</div>
-		</div>
+		</li>
 	);
 };

--- a/src/views/explore/homepage.astro
+++ b/src/views/explore/homepage.astro
@@ -64,15 +64,13 @@ const postAuthors = new Map(
 	>
 		{
 			collections.map((collection) => (
-				<li>
-					<CollectionCard
-						collection={collection}
-						authors={collection.authors
-							.map((id) => api.getPersonById(id, collection.locale))
-							.filter(isDefined)}
-						headingTag="h3"
-					/>
-				</li>
+				<CollectionCard
+					collection={collection}
+					authors={collection.authors
+						.map((id) => api.getPersonById(id, collection.locale))
+						.filter(isDefined)}
+					headingTag="h3"
+				/>
 			))
 		}
 	</ul>

--- a/src/views/search/search-page.tsx
+++ b/src/views/search/search-page.tsx
@@ -395,15 +395,13 @@ export function SearchPageBase() {
 									className={style.collectionsGrid}
 								>
 									{data.collections.map((collection) => (
-										<li>
-											<CollectionCard
-												collection={collection}
-												authors={collection.authors
-													.map((id) => peopleMap.get(id + ""))
-													.filter(isDefined)}
-												headingTag="h3"
-											/>
-										</li>
+										<CollectionCard
+											collection={collection}
+											authors={collection.authors
+												.map((id) => peopleMap.get(id + ""))
+												.filter(isDefined)}
+											headingTag="h3"
+										/>
 									))}
 								</ul>
 							</Fragment>


### PR DESCRIPTION
Fixes #1255 

Adds `align-self` so that the collection card button & cover image do not automatically use the max size of the flex container.