### PR TITLE
chore: remove old GA preconnects

### DIFF
--- a/src/components/seo/analytics.astro
+++ b/src/components/seo/analytics.astro
@@ -1,3 +1,0 @@
-{/* Google Analytics */}
-<link rel="preconnect" href="https://www.google.com" />
-<link rel="preconnect" href="https://marketingplatform.google.com" />

--- a/src/components/seo/seo.astro
+++ b/src/components/seo/seo.astro
@@ -4,7 +4,6 @@ import {
 	getPrefixLanguageFromPath,
 	removePrefixLanguageFromPath,
 } from "utils/translations";
-import Analytics from "./analytics.astro";
 import Article from "./article.astro";
 import Book from "./book.astro";
 import Locale from "./locale.astro";
@@ -78,7 +77,6 @@ const currentPath = removeTrailingSlash(
 	noindex ? <meta name="robots" content="noindex, nofollow" /> : null
 }
 
-<Analytics />
 <Twitter
 	title={title}
 	metaDescription={metaDescription}


### PR DESCRIPTION
Found these while looking through our SEO component. Shouldn't be needed anymore