### PR TITLE
Fix button stretching by setting an explicit height value.

### DIFF
--- a/src/styles/button.scss
+++ b/src/styles/button.scss
@@ -97,6 +97,7 @@
 }
 
 .button {
+	height: fit-content;
 	border-radius: var(--corner-radius_circular);
 
 	display: flex;


### PR DESCRIPTION
Buttons would sometimes auto stretch vertically due to it not having an explicit height value. Particularly in Join Us, as shown below.

![image](https://github.com/user-attachments/assets/771b18da-70bb-4734-86b0-2f4e1bf8338a)

While my original fix was local to that page — setting the grid to have an explicit height of min-content, it would've resulted in a whack-a-mole scenario.
