### PR TITLE
fix: heading styling in blog posts can now be overwritten

### DIFF
--- a/src/styles/markdown/base.scss
+++ b/src/styles/markdown/base.scss
@@ -10,49 +10,49 @@
 }
 
 .post-body {
-  h1 {
+  h1:not([class]) {
     @extend .text-style-headline-1;
     margin: 0 auto;
     margin-top: var(--h1_block-padding-top);
     margin-bottom: var(--h1_block-padding-bottom);
   }
 
-  h2 {
+  h2:not([class]) {
     @extend .text-style-headline-2;
     margin: 0 auto;
     margin-top: var(--h2_block-padding-top);
     margin-bottom: var(--h2_block-padding-bottom);
   }
 
-  h3 {
+  h3:not([class]) {
     @extend .text-style-headline-3;
     margin: 0 auto;
     margin-top: var(--h3_block-padding-top);
     margin-bottom: var(--h3_block-padding-bottom);
   }
 
-  h4 {
+  h4:not([class]) {
     @extend .text-style-headline-4;
     margin: 0 auto;
     margin-top: var(--h4_block-padding-top);
     margin-bottom: var(--h4_block-padding-bottom);
   }
 
-  h5 {
+  h5:not([class]) {
     @extend .text-style-headline-5;
     margin: 0 auto;
     margin-top: var(--h5_block-padding-top);
     margin-bottom: var(--h5_block-padding-bottom);
   }
 
-  h6 {
+  h6:not([class]) {
     @extend .text-style-headline-6;
     margin: 0 auto;
     margin-top: var(--h6_block-padding-top);
     margin-bottom: var(--h6_block-padding-bottom);
   }
 
-  p {
+  p:not([class]) {
     @extend .text-style-body-large;
     margin-top: var(--p_block-padding-vertical);
     margin-bottom: var(--p_block-padding-vertical);


### PR DESCRIPTION
Even though this heading is `<h3>`, it was originally an `h2` from our markdown before we run `behead` over it

So we add a `text-style-headline-2` on it to style it as an `h2`

But due to our `:where` specificity it never applies that class to our `h3` so it stays styled as an `h3` instead of visually an `h2`

![image](https://github.com/user-attachments/assets/52dbcd88-cb8f-4fef-944c-285242d79013)

This PR fixes this issue