### PR TITLE
fix: remove prefix labels on A11Y art page

### DIFF
--- a/src/pages/collections/art-of-accessibility/index.astro
+++ b/src/pages/collections/art-of-accessibility/index.astro
@@ -50,6 +50,7 @@ const chapterList = getPostsByCollection("art-of-accessibility", "en");
 				chaptersToShow={5}
 				chapterList={collection!.chapterList}
 				posts={chapterList}
+				postPrefixToRemove="The Art of Accessibility: "
 			/>
 			<BottomContents />
 		</Rest>

--- a/src/views/collections/framework-field-guide-fundamentals/components/collection-table-of-contents-fundamentals.astro
+++ b/src/views/collections/framework-field-guide-fundamentals/components/collection-table-of-contents-fundamentals.astro
@@ -8,12 +8,20 @@ interface CollectionTableOfContentsProps {
 	posts: PostInfo[];
 	chapterList?: ChapterList[];
 	chaptersToShow?: number;
+	postPrefixToRemove?: string;
 }
 
-const { title, posts, chapterList, chaptersToShow } =
+const { title, posts, chapterList, chaptersToShow, postPrefixToRemove } =
 	Astro.props as CollectionTableOfContentsProps;
 
 const maxChapterToShow = chaptersToShow ?? 10;
+
+function removeTitlePrefix(title: string) {
+	if (postPrefixToRemove && title.startsWith(postPrefixToRemove)) {
+		return title.slice(postPrefixToRemove.length);
+	}
+	return title;
+}
 ---
 
 <section class={styles.chaptersContainer}>
@@ -45,7 +53,7 @@ const maxChapterToShow = chaptersToShow ?? 10;
 									.
 								</span>
 								<span class={`text-style-body-large-bold ${styles.postTitle}`}>
-									{post.title}
+									{removeTitlePrefix(post.title)}
 								</span>
 								<span
 									class={`text-style-button ffg-button-base ffg-small-button ffg-outlined-button ${styles.noOutlineButton}`}
@@ -80,7 +88,7 @@ const maxChapterToShow = chaptersToShow ?? 10;
 									{isNumber ? "." : " "}
 								</span>
 								<span class={`text-style-body-large-bold ${styles.postTitle}`}>
-									{post.title}
+									{removeTitlePrefix(post.title)}
 								</span>
 								{post.description ? (
 									<span


### PR DESCRIPTION
Removes the "The Art of Accessibility: " label from the marketing homepage's site:

![image](https://github.com/user-attachments/assets/f211b675-dd44-40b3-9cab-3b2f60de9ee2)
