### PR TITLE
Improve search page a11y and seo

### DIFF
--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -1,4 +1,5 @@
 ---
+import style from "../views/search/search-page.module.scss";
 import SearchPage from "../views/search/search-page";
 import Document from "../layouts/document.astro";
 import SEO from "../components/seo/seo.astro";
@@ -13,6 +14,11 @@ import { siteMetadata } from "constants/site-config";
 	/>
 	<main>
 		<h1 class="visually-hidden">Search</h1>
+		<noscript>
+			<h3 class={style.centerHeader}>
+				JavaScript needs to be enabled to use this page
+			</h3>
+		</noscript>
 		<SearchPage client:only="preact" siteTitle={siteMetadata.title} />
 	</main>
 </Document>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -15,9 +15,9 @@ import { siteMetadata } from "constants/site-config";
 	<main>
 		<h1 class="visually-hidden">Search</h1>
 		<noscript>
-			<h3 class={style.centerHeader}>
+			<p class={`text-style-headline-3 ${style.centerHeader}`}>
 				JavaScript needs to be enabled to use this page
-			</h3>
+			</p>
 		</noscript>
 		<SearchPage client:only="preact" siteTitle={siteMetadata.title} />
 	</main>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -1,5 +1,4 @@
 ---
-import style from "../views/search/search-page.module.scss";
 import SearchPage from "../views/search/search-page";
 import Document from "../layouts/document.astro";
 import SEO from "../components/seo/seo.astro";
@@ -12,7 +11,7 @@ import { siteMetadata } from "constants/site-config";
 		description="Find your favorite articles and collections on Playful Programming easier than ever!"
 		slot="head"
 	/>
-	<main class={style.fullPageContainer} id="search-container">
+	<main>
 		<h1 class="visually-hidden">Search</h1>
 		<SearchPage client:only="preact" siteTitle={siteMetadata.title} />
 	</main>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -1,4 +1,5 @@
 ---
+import style from "../views/search/search-page.module.scss";
 import SearchPage from "../views/search/search-page";
 import Document from "../layouts/document.astro";
 import SEO from "../components/seo/seo.astro";
@@ -11,5 +12,8 @@ import { siteMetadata } from "constants/site-config";
 		description="Find your favorite articles and collections on Playful Programming easier than ever!"
 		slot="head"
 	/>
-	<SearchPage client:only="preact" siteTitle={siteMetadata.title} />
+	<main class={style.fullPageContainer} id="search-container">
+		<h1 class="visually-hidden">Search</h1>
+		<SearchPage client:only="preact" siteTitle={siteMetadata.title} />
+	</main>
 </Document>

--- a/src/views/search/search-page.module.scss
+++ b/src/views/search/search-page.module.scss
@@ -49,6 +49,10 @@
 	}
 }
 
+.centerHeader {
+	text-align: center;
+}
+
 @keyframes play36 {
 	0% {
 		background-position: 0px 0px;

--- a/src/views/search/search-page.tsx
+++ b/src/views/search/search-page.tsx
@@ -222,17 +222,6 @@ export function SearchPageBase({ siteTitle }: RootSearchPageProps) {
 		}
 	}, [errorData]);
 
-	useEffect(() => {
-		const searchContainer = document.querySelector(
-			"#search-container",
-		) as HTMLElement;
-		if (query.searchQuery) {
-			searchContainer.setAttribute("data-hide-sidebar", "false");
-		} else {
-			searchContainer.setAttribute("data-hide-sidebar", "true");
-		}
-	}, [query.searchQuery]);
-
 	const isContentLoading =
 		isLoadingData || isFetchingData || isLoadingPeople || isFetchingPeople;
 
@@ -333,7 +322,10 @@ export function SearchPageBase({ siteTitle }: RootSearchPageProps) {
 	const numberOfPosts = showArticles ? data.totalPosts : 0;
 
 	return (
-		<>
+		<div
+			className={style.fullPageContainer}
+			data-hide-sidebar={!query.searchQuery}
+		>
 			<FilterDisplay
 				isFilterDialogOpen={isFilterDialogOpen}
 				setFilterIsDialogOpen={setFilterIsDialogOpen}
@@ -542,7 +534,7 @@ export function SearchPageBase({ siteTitle }: RootSearchPageProps) {
 					)}
 				</section>
 			</div>
-		</>
+		</div>
 	);
 }
 

--- a/src/views/search/search-page.tsx
+++ b/src/views/search/search-page.tsx
@@ -81,7 +81,7 @@ export function SearchPageBase({ siteTitle }: RootSearchPageProps) {
 				return `${query.searchQuery} | ${siteTitle}`;
 			}
 			return `Search | ${siteTitle}`;
-		}
+		},
 	);
 
 	const setQuery = useCallback(
@@ -322,11 +322,7 @@ export function SearchPageBase({ siteTitle }: RootSearchPageProps) {
 	const numberOfPosts = showArticles ? data.totalPosts : 0;
 
 	return (
-		<main
-			className={style.fullPageContainer}
-			data-hide-sidebar={!query.searchQuery}
-		>
-			<h1 className={"visually-hidden"}>Search</h1>
+		<>
 			<FilterDisplay
 				isFilterDialogOpen={isFilterDialogOpen}
 				setFilterIsDialogOpen={setFilterIsDialogOpen}
@@ -535,7 +531,7 @@ export function SearchPageBase({ siteTitle }: RootSearchPageProps) {
 					)}
 				</section>
 			</div>
-		</main>
+		</>
 	);
 }
 

--- a/src/views/search/search-page.tsx
+++ b/src/views/search/search-page.tsx
@@ -222,6 +222,17 @@ export function SearchPageBase({ siteTitle }: RootSearchPageProps) {
 		}
 	}, [errorData]);
 
+	useEffect(() => {
+		const searchContainer = document.querySelector(
+			"#search-container",
+		) as HTMLElement;
+		if (query.searchQuery) {
+			searchContainer.setAttribute("data-hide-sidebar", "false");
+		} else {
+			searchContainer.setAttribute("data-hide-sidebar", "true");
+		}
+	}, [query.searchQuery]);
+
 	const isContentLoading =
 		isLoadingData || isFetchingData || isLoadingPeople || isFetchingPeople;
 


### PR DESCRIPTION
Fixes #856

This PR moves the `main` & `h1` elements outside the `search-page.tsx` component to the `search.astro` component to improve a11y and SEO.

An effect is now used to toggle the change when the sidebar is shown