### PR TITLE
Fix broken links

### DIFF
--- a/content/20jasper/posts/iifes-a-javascript-idiom-of-yore/index.md
+++ b/content/20jasper/posts/iifes-a-javascript-idiom-of-yore/index.md
@@ -38,7 +38,7 @@ Prior to ES5/ES2015, variables would be function scoped with `var` or globally s
 
 This means that block scope effectively did not exist, and functions were the smallest scope[^tryCatchScope]
 
-[^tryCatchScope]: Catch blocks scope caught variables to the block as of ES3. They are smaller than the function scope mentioned, just not very useful to scope non-thrown variables. [Mozilla Scope Cheat Sheet](scopeCheatSheet)
+[^tryCatchScope]: Catch blocks scope caught variables to the block as of ES3. They are smaller than the function scope mentioned, just not very useful to scope non-thrown variables. [Mozilla Scope Cheat Sheet][scopeCheatSheet]
 
 [scopeCheatSheet]: https://web.archive.org/web/20121022212951/https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Scope_Cheatsheet
 

--- a/content/crutchcorn/collections/framework-field-guide-ecosystem/posts/ffg-ecosystem-bundling/index.md
+++ b/content/crutchcorn/collections/framework-field-guide-ecosystem/posts/ffg-ecosystem-bundling/index.md
@@ -16,7 +16,7 @@ There are many good options out there for bundling today:
 - [Rspack](https://www.rspack.dev/)
 - [Turbopack](https://turbo.build/pack)
 
-While each comes with their own pros and cons, we're instead going to be focusing on [Vite](https://vitejs.dev/). Here's why:
+While each comes with their own pros and cons, we're instead going to be focusing on [Vite](https://vite.dev/). Here's why:
 
 - Vite is the suggested bundler for Vue apps and is maintained by many of the Vue maintainers
 - Vite is used by Angular's tooling to host a development server (more on that soon)
@@ -665,7 +665,7 @@ And finally, this `App` component might be bundled with other code to create the
 
 Let's take our knowledge of bundlers out of theoretical land and move onto implementing them in an app with our chosen framework.
 
-As we mentioned at the start of the article, while there are many options for bundlers these days, we'll be using [Vite](https://vitejs.dev/) for its ubiquitous usage and simplicity of setup.
+As we mentioned at the start of the article, while there are many options for bundlers these days, we'll be using [Vite](https://vite.dev/) for its ubiquitous usage and simplicity of setup.
 
 <!-- ::start:tabs -->
 
@@ -725,7 +725,7 @@ Now when you modify `src/App.jsx` (or `src/App.tsx` if you selected TypeScript) 
 
 Angular, being an "everything, including the kitchen sink" framework, has an official solution to the bundling solution.
 
-This solution can be found in the shape of [the Angular CLI](https://angular.io/cli), which uses [Vite](https://vitejs.dev/) (and Vite's dependency, [ESBuild](https://esbuild.github.io/)) under-the-hood.
+This solution can be found in the shape of [the Angular CLI](https://angular.io/cli), which uses [Vite](https://vite.dev/) (and Vite's dependency, [ESBuild](https://esbuild.github.io/)) under-the-hood.
 
 ------
 
@@ -776,7 +776,7 @@ Now, by modifying the source code in `src`, you're able to see the browser conte
 
 To spin up a fresh Vue project, you have two options:
 
-- The [`create-vite`](https://vitejs.dev/guide/#scaffolding-your-first-vite-project) NPM package
+- The [`create-vite`](https://vite.dev/guide/#scaffolding-your-first-vite-project) NPM package
 - The [`create-vue`](https://github.com/vuejs/create-vue) NPM package
 
 The while we've been using something akin to the more minimal output from `create-vite` in the first book, the official recommendation for spinning up a new Vue project is _actually_ the `create-vue` package, as it includes more built-in functionality that most production apps can leverage.

--- a/content/crutchcorn/collections/framework-field-guide-ecosystem/posts/ffg-ecosystem-styling/index.md
+++ b/content/crutchcorn/collections/framework-field-guide-ecosystem/posts/ffg-ecosystem-styling/index.md
@@ -17,7 +17,7 @@ Just to name a few, here are some of the styling tools we're **not** talking abo
 - [Styled Components](https://styled-components.com/)
 - [StyleX](https://stylexjs.com/)
 - [UnoCSS](https://unocss.dev/)
-- [Vanilla Extract](vanilla-extract.style/)
+- [Vanilla Extract](https://vanilla-extract.style/)
 - [Less](https://lesscss.org/)
 
 Given the broad range and number of tools we aren't looking at, what tools _are_ we going to be learning about? Well, in addition to a few built-in browser techniques, we'll touch on:
@@ -314,7 +314,7 @@ Finally, we'll import our `src/styles.css` file into Vite's entry point of `inde
 
 #### Angular
 
-Since the Angular CLI supports [PostCSS](https://postcss.org/https://postcss.org/) out-of-the-box, we can leverage it to add Tailwind.
+Since the Angular CLI supports [PostCSS](https://postcss.org/) out-of-the-box, we can leverage it to add Tailwind.
 
 > PostCSS is a CSS transformer that powers Tailwind's compilation of your CSS. (more on this later)
 

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/index.md
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/index.md
@@ -376,7 +376,7 @@ createApp(File).mount("#root");
 
 Once a component is rendered, you can do a lot more with it!
 
-For example, just like [nodes in the DOM]() have relationships, so too can components.
+For example, just like nodes in the DOM have relationships, so too can components.
 
 # Children, Siblings, and More, Oh My! {#relationships}
 

--- a/content/crutchcorn/collections/react-beyond-the-render/posts/what-are-react-server-actions/index.md
+++ b/content/crutchcorn/collections/react-beyond-the-render/posts/what-are-react-server-actions/index.md
@@ -385,7 +385,7 @@ React Server Actions not only make it easier to call data from the server from t
 For example, assume you're building a payment form:
 ![A payment form with card information and more](./shadcn_payment.png)
 
-> This payment card graphic comes from [`shadcn/ui`'s examples](https://ui.shadcn.com/examples/cards)
+> This payment card graphic comes from [`shadcn/ui`'s examples](https://ui.shadcn.com/)
 
 You want this payment form to be bulletproof. Any user having to attempt a re-purchase will likely not return to your site; leading to lost sales.
 

--- a/content/crutchcorn/posts/angular-pipes-a-complete-guide/index.md
+++ b/content/crutchcorn/posts/angular-pipes-a-complete-guide/index.md
@@ -352,7 +352,7 @@ We can add `pure: false` to the pipe and, voila, it works!
 
 # Using Services in Pipes
 
-Some folks have asked me how they can use [Angular's dependency injection](posts/ffg-fundamentals-dependency-injection) in pipes.
+Some folks have asked me how they can use [Angular's dependency injection](/posts/ffg-fundamentals-dependency-injection) in pipes.
 
 Well, luckily for us it's no different than using the `inject` function in a `@Component` or `@Directive`:
 

--- a/content/crutchcorn/posts/react-history-through-code/index.md
+++ b/content/crutchcorn/posts/react-history-through-code/index.md
@@ -971,7 +971,7 @@ Lazy loading components enable React to tree-shake away the bundled code relevan
 
 > **Further reading:**
 >
-> Confused by what a "bundle" is in this context? Worry not! [I've written a guide to bundling (the process of generating a bundle) in React inside my free book "Framework Field Guide: Ecosystem"](posts/ffg-ecosystem-bundling).
+> Confused by what a "bundle" is in this context? Worry not! [I've written a guide to bundling (the process of generating a bundle) in React inside my free book "Framework Field Guide: Ecosystem"](/posts/ffg-ecosystem-bundling).
 
 This enabled further usage of the VDOM as a representation of complex state by loading in a component and its associated code over the network (in this case `LargeBundleComponent`).
 
@@ -1861,7 +1861,7 @@ While this project never left the experimental phase, it was clear that Facebook
 
 In face, [in an interview with Dominic Gannaway, an ex-React core team member](https://www.youtube.com/live/N54FZtNvk_A?t=2318s), he outlined that the history of investigations around the React Compiler _predates Hooks_. Yes, that's right, the rules of Hooks were not just created for the code at the time, but were a massive future-think from the team to enable functionalities like the current React Compiler.
 
-And it's not like React is the only framework with required performance optimizations. Between [Angular's `runOutsideAngular` from its Zone.js days](posts/angular-internals-zonejs) to [its modern `OnPush` detection strategies](https://angular.dev/best-practices/skipping-subtrees), [Vue's `v-memo` and `v-once`](https://angular.dev/best-practices/skipping-subtrees), [Lit's `shouldUpdate`](https://lit.dev/docs/components/lifecycle/#shouldupdate), and even [Solid.js' `createMemo`](https://docs.solidjs.com/reference/basic-reactivity/create-memo), it's clear that there's no silver bullet to performance, regardless of [reactivity mechanism](/posts/what-is-reactivity).
+And it's not like React is the only framework with required performance optimizations. Between [Angular's `runOutsideAngular` from its Zone.js days](/posts/angular-internals-zonejs) to [its modern `OnPush` detection strategies](https://angular.dev/best-practices/skipping-subtrees), [Vue's `v-memo` and `v-once`](https://angular.dev/best-practices/skipping-subtrees), [Lit's `shouldUpdate`](https://lit.dev/docs/components/lifecycle/#shouldupdate), and even [Solid.js' `createMemo`](https://docs.solidjs.com/reference/basic-reactivity/create-memo), it's clear that there's no silver bullet to performance, regardless of [reactivity mechanism](/posts/what-is-reactivity).
 
 # Takeaways
 

--- a/content/crutchcorn/posts/setup-a-react-native-monorepo/index.md
+++ b/content/crutchcorn/posts/setup-a-react-native-monorepo/index.md
@@ -385,9 +385,9 @@ While our IDE isn't showing any errors, if we attempt to consume our library in 
 
 To transform these source files, we need to configure a "Bundler" to take our source code files and turn them into compiled files to be used by our apps.
 
-While we could theoretically use any other bundler, I find that [Vite](https://vitejs.dev/) is the easiest to configure and provides the nicest developer experience out-of-the-box.
+While we could theoretically use any other bundler, I find that [Vite](https://vite.dev/) is the easiest to configure and provides the nicest developer experience out-of-the-box.
 
-Using [Vite's React plugin](https://github.com/vitejs/vite-plugin-react) and [Vite's library mode](https://vitejs.dev/guide/build.html#library-mode), we can easily generate `.js` files for our source code. Combined with [`vite-plugin-dts`](https://www.npmjs.com/package/vite-plugin-dts), we can even generate `.d.ts` files for TypeScript to get our typings as well.
+Using [Vite's React plugin](https://github.com/vitejs/vite-plugin-react) and [Vite's library mode](https://vite.dev/guide/build.html#library-mode), we can easily generate `.js` files for our source code. Combined with [`vite-plugin-dts`](https://www.npmjs.com/package/vite-plugin-dts), we can even generate `.d.ts` files for TypeScript to get our typings as well.
 
 Here's what an example `vite.config.ts` file - placed in `/packages/shared-elements/` - might look like:
 

--- a/content/crutchcorn/posts/web-framework-quickstart-guide/index.md
+++ b/content/crutchcorn/posts/web-framework-quickstart-guide/index.md
@@ -20,7 +20,7 @@ Let's take a quick look at how we can scaffold a project for React, Angular, and
 
 While React used to have a dedicated tool called `create-react-app`, it's [no longer suggested to use for modern React apps.](https://github.com/reactjs/react.dev/pull/5487#issuecomment-1409720741)
 
-Instead, we can use a tool built by the Vue maintainers (of all things!) that supports React and other frameworks as first-party integrations: [**Vite**](https://vitejs.dev/). 
+Instead, we can use a tool built by the Vue maintainers (of all things!) that supports React and other frameworks as first-party integrations: [**Vite**](https://vite.dev/). 
 
 ![The Vite logo: A "V" with a lightning strike in the middle](./vite_og.png)
 
@@ -151,7 +151,7 @@ Now when you modify any code in the project it will refresh the screen for you a
 
 # Vue
 
-While Vue used to have a CLI tool aptly named "Vue CLI" that let you scaffold projects, it's been replaced by a new tool made by the Vue team: [**Vite**](https://vitejs.dev/).
+While Vue used to have a CLI tool aptly named "Vue CLI" that let you scaffold projects, it's been replaced by a new tool made by the Vue team: [**Vite**](https://vite.dev/).
 
 ![The Vite logo: A "V" with a lightning strike in the middle](./vite_og.png)
 

--- a/content/edpratti/posts/figma-compose-line-height/index.md
+++ b/content/edpratti/posts/figma-compose-line-height/index.md
@@ -11,7 +11,7 @@
 > **This is an update to an existing article:**
 > If you haven't yet, check the original article below.
 >
-> **[Hard grids & baselines: How I achieved 1:1 fidelity on Android](hard-grids-and-baselines-android-design-fidelity)**
+> **[Hard grids & baselines: How I achieved 1:1 fidelity on Android](/posts/hard-grids-and-baselines-android-design-fidelity)**
 
 For years, the difference between web and native line heights has been a problem for designers. Figma behaves similarly to the web, which ended up being an issue when designing for Android and iOS.
 

--- a/content/ljtech/collections/web-fundamentals/posts/web-fundamentals-grid/index.md
+++ b/content/ljtech/collections/web-fundamentals/posts/web-fundamentals-grid/index.md
@@ -191,7 +191,7 @@ In those situations, you can specify the size of auto generated cells.
 
 # Alignment 
 
-Adding `display: grid` to a container will cause any immediate descendants to become grid items. Similar to **[flexbox](./web-fundamentals-flexbox)**, we can use placement methods to help align, justify, and space grid items inside the container.
+Adding `display: grid` to a container will cause any immediate descendants to become grid items. Similar to **[flexbox](/posts/web-fundamentals-flexbox)**, we can use placement methods to help align, justify, and space grid items inside the container.
 
 
 ## Using `place-items`

--- a/content/ljtech/collections/web-fundamentals/posts/web-fundamentals-html/index.md
+++ b/content/ljtech/collections/web-fundamentals/posts/web-fundamentals-html/index.md
@@ -59,7 +59,7 @@ The problem is that, when not using semantic elements, the user is not given the
 
 It's important to understand that semantic elements are best practice for a reason, and accessibility should always be a priority. If you'd like to learn more, we have a fantastic post going over web accessibility.
 
-> #### **[Intro to accessibility](./intro-to-web-accessibility)**
+> #### **[Intro to accessibility](/posts/intro-to-web-accessibility)**
 > Accessibility allows as many people to use your product as possible. That, in turn, generates more profit. Here's how to improve it on web.
 
 Now let's dive into the elements, shall we?

--- a/content/ljtech/collections/web-fundamentals/posts/web-fundamentals-javascript-basics/index.md
+++ b/content/ljtech/collections/web-fundamentals/posts/web-fundamentals-javascript-basics/index.md
@@ -255,7 +255,7 @@ Besides that, arrow functions differ in one important area: The context of the `
 
 ### Calling functions as values
 
-> 📝 **[Functions, in and of themselves, are values.](./javascript-functions-are-values)**<br>
+> 📝 **[Functions, in and of themselves, are values.](/posts/javascript-functions-are-values)**<br>
 > We have an article that goes over this in much more detail. Please check it out to learn more.
 
 We can encapsulate functions and their returns in variables.

--- a/content/rollbear/posts/compile-time-messages-in-c/index.md
+++ b/content/rollbear/posts/compile-time-messages-in-c/index.md
@@ -14,7 +14,7 @@
 At times, it's desirable to give a message at compile time. Sounds cheesy, eh? Well, read on and find out.
 
 As an example of the cheesy kind, the compile-time quick sort shown
-here [**earlier**](./compile-time-quick-sort-using-c) contained an
+here [**earlier**](/posts/compile-time-quick-sort-using-c) contained an
 unnecessary run time element with a `main()` function, `for_each()` and a `print` template. It is possible to display
 all
 information at compile time by causing a compiler error, like this:

--- a/content/tylerlwsmith/posts/build-a-vite-5-backend-integration-with-flask/index.md
+++ b/content/tylerlwsmith/posts/build-a-vite-5-backend-integration-with-flask/index.md
@@ -10,7 +10,7 @@
 }
 ---
 
-The [Vite Backend Integration guide](https://vitejs.dev/guide/backend-integration.html) is light on details; it asks the reader to consider using an existing integration. This isn't helpful when an integration doesn't yet exist, or when you want to develop your own integration for a traditional server-rendered web application. I wasn't able to find a complete integration guide, so I decided to write my own that shares what I've learned about bundling with Vite.
+The [Vite Backend Integration guide](https://vite.dev/guide/backend-integration.html) is light on details; it asks the reader to consider using an existing integration. This isn't helpful when an integration doesn't yet exist, or when you want to develop your own integration for a traditional server-rendered web application. I wasn't able to find a complete integration guide, so I decided to write my own that shares what I've learned about bundling with Vite.
 
 This guide will show you how to bundle assets with Vite and build a lightweight integration with a traditional backend framework. The guide will use Python & Flask because they are accessible tools for developers across multiple ecosystems. However, the concepts could be applied to Django, Gorilla Mux, WordPress themes, and countless other backend technologies. 
 
@@ -33,7 +33,7 @@ Vite's DevServer was designed from its inception to make local development chang
 
 Unlike Webpack, the Vite DevServer only compiles files when they are requested. It leverages [ES module](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) imports, which allow JS files to import other files without needing to bundle them together during development. When one file changes, only that file needs to be re-compiled, and the rest can remain unchanged. Project files are compiled with [Rollup.js](https://rollupjs.org/). Third-party dependencies in `node_modules` are pre-compiled using the ultra-fast [esbuild](https://esbuild.github.io/) bundler for maximum speed, and they are cached until the dependency version changes. Vite also provides a client script for hot module reloading.
 
-Within the Vite config, there is a `root` option that specifies the directory where Vite will look for unprocessed assets. When running the Vite DevServer, almost every file in the `root` directory is URL-accessible by its unprocessed filename (see [blocked files](https://vitejs.dev/config/server-options.html#server-fs-deny)). For example, `{root}/src/main.ts` would be URL accessible at `http://localhost:5173/src/main.ts`, and it would return the compiled JS file. However, this does not mean that every file in the `root` directory will be included in the production bundle (more on this in the [next section](#the-vite-bundler)).
+Within the Vite config, there is a `root` option that specifies the directory where Vite will look for unprocessed assets. When running the Vite DevServer, almost every file in the `root` directory is URL-accessible by its unprocessed filename (see [blocked files](https://vite.dev/config/server-options.html#server-fs-deny)). For example, `{root}/src/main.ts` would be URL accessible at `http://localhost:5173/src/main.ts`, and it would return the compiled JS file. However, this does not mean that every file in the `root` directory will be included in the production bundle (more on this in the [next section](#the-vite-bundler)).
 
 Another interesting quirk of the Vite DevServer is _when_ and _how_ the compiling of an asset happens. Let's say the following Sass file exists at `{root}/example.scss` in a Vite project:
 
@@ -100,7 +100,7 @@ Not all files in the `root` directory will be bundled. For a file to be included
 2. The file is included directly or transitively by an entry point.
 3. The file is in the `{root}/public/` directory (however, our integration will disable this feature).
 
-An **entry point** is a top-level file in a bundle that will have an associated output file in the build. Vite allows multiple entry points in a project. An entry point can be an HTML file, a JavaScript file, a TypeScript file, an Scss file, or another supported file type that's listed on [Vite's Features page](https://vitejs.dev/guide/features.html).
+An **entry point** is a top-level file in a bundle that will have an associated output file in the build. Vite allows multiple entry points in a project. An entry point can be an HTML file, a JavaScript file, a TypeScript file, an Scss file, or another supported file type that's listed on [Vite's Features page](https://vite.dev/guide/features.html).
 
 During the build phase, Vite will ensure that all files referenced by an entry point (such as JS, CSS, and images) will be bundled. In our integration, the entry points will be styles and scripts.
 
@@ -124,7 +124,7 @@ Our integration will _not_ use the module preload polyfill (more info [here](htt
 
 ## Scaffolding the project
 
-Create a new Vite project using the `vanilla-ts` template (you can find other template options in [Vite's Getting Started guide](https://vitejs.dev/guide/#scaffolding-your-first-vite-project)).
+Create a new Vite project using the `vanilla-ts` template (you can find other template options in [Vite's Getting Started guide](https://vite.dev/guide/#scaffolding-your-first-vite-project)).
 
 ```sh
 npm create vite@latest vite-flask-integration -- \

--- a/src/utils/markdown/createEpubPlugins.ts
+++ b/src/utils/markdown/createEpubPlugins.ts
@@ -27,6 +27,7 @@ import {
 import { rehypePostShikiTransform } from "./shiki/rehype-post-shiki-transform";
 import { rehypeRemoveCollectionLinks } from "./rehype-remove-collection-links";
 import { rehypeReferencePage } from "./reference-page/rehype-reference-page";
+import { rehypeRelativePaths } from "./rehype-relative-paths";
 
 export function createEpubPlugins(unified: Processor) {
 	return (
@@ -42,6 +43,7 @@ export function createEpubPlugins(unified: Processor) {
 			.use(rehypeUnwrapImages)
 			// This is required to handle unsafe HTML embedded into Markdown
 			.use(rehypeRaw, { passThrough: ["mdxjsEsm"] } as never)
+			.use(rehypeRelativePaths)
 			.use(rehypeParseComponents)
 			// When generating an epub, any relative paths need to be made absolute
 			.use(rehypeFixTwoSlashXHTML)

--- a/src/utils/markdown/createHtmlPlugins.ts
+++ b/src/utils/markdown/createHtmlPlugins.ts
@@ -41,6 +41,7 @@ import {
 	transformTabs,
 	transformVoid,
 } from "./components";
+import { rehypeRelativePaths } from "./rehype-relative-paths";
 
 const currentBranch = process.env.VERCEL_GIT_COMMIT_REF ?? (await branch());
 
@@ -74,6 +75,7 @@ export function createHtmlPlugins(unified: Processor) {
 			.use(rehypeUnwrapImages)
 			// This is required to handle unsafe HTML embedded into Markdown
 			.use(rehypeRaw, { passThrough: ["mdxjsEsm"] })
+			.use(rehypeRelativePaths)
 			.use(rehypeParseComponents)
 			// Do not add the tabs before the slug. We rely on some of the heading
 			// logic in order to do some of the subheading logic

--- a/src/utils/markdown/rehype-absolute-paths.ts
+++ b/src/utils/markdown/rehype-absolute-paths.ts
@@ -1,10 +1,9 @@
 import { Element, Root } from "hast";
 import { isURL } from "../url-paths";
 import { visit } from "unist-util-visit";
-import { dirname, join, relative } from "path";
+import { dirname, join } from "path";
 import { Plugin } from "unified";
 import { VFile } from "vfile";
-import { isMarkdownVFile } from "./types";
 
 export const rehypeMakeImagePathsAbsolute: Plugin<[], Root> = () => {
 	return (tree: Root, file: VFile) => {
@@ -31,12 +30,7 @@ export const rehypeMakeImagePathsAbsolute: Plugin<[], Root> = () => {
 };
 
 export const rehypeMakeHrefPathsAbsolute: Plugin<[], Root> = () => {
-	return (tree, vfile) => {
-		let path = "";
-		if (isMarkdownVFile(vfile)) {
-			const file = relative(process.cwd(), vfile.data.file);
-			path = dirname(file) + "/";
-		}
+	return (tree) => {
 		function aVisitor(node: Element) {
 			if (node.tagName === "a") {
 				const href = node.properties!.href as string;
@@ -45,7 +39,7 @@ export const rehypeMakeHrefPathsAbsolute: Plugin<[], Root> = () => {
 				}
 				node.properties!.href = new URL(
 					href,
-					"https://playfulprogramming.com/" + path,
+					"https://playfulprogramming.com",
 				).toString();
 			}
 		}

--- a/src/utils/markdown/rehype-absolute-paths.ts
+++ b/src/utils/markdown/rehype-absolute-paths.ts
@@ -1,9 +1,10 @@
 import { Element, Root } from "hast";
 import { isURL } from "../url-paths";
 import { visit } from "unist-util-visit";
-import { dirname, join } from "path";
+import { dirname, join, relative } from "path";
 import { Plugin } from "unified";
 import { VFile } from "vfile";
+import { isMarkdownVFile } from "./types";
 
 export const rehypeMakeImagePathsAbsolute: Plugin<[], Root> = () => {
 	return (tree: Root, file: VFile) => {
@@ -30,7 +31,12 @@ export const rehypeMakeImagePathsAbsolute: Plugin<[], Root> = () => {
 };
 
 export const rehypeMakeHrefPathsAbsolute: Plugin<[], Root> = () => {
-	return (tree) => {
+	return (tree, vfile) => {
+		let path = "";
+		if (isMarkdownVFile(vfile)) {
+			const file = relative(process.cwd(), vfile.data.file);
+			path = dirname(file) + "/";
+		}
 		function aVisitor(node: Element) {
 			if (node.tagName === "a") {
 				const href = node.properties!.href as string;
@@ -39,7 +45,7 @@ export const rehypeMakeHrefPathsAbsolute: Plugin<[], Root> = () => {
 				}
 				node.properties!.href = new URL(
 					href,
-					"https://playfulprogramming.com",
+					"https://playfulprogramming.com/" + path,
 				).toString();
 			}
 		}

--- a/src/utils/markdown/rehype-relative-paths.ts
+++ b/src/utils/markdown/rehype-relative-paths.ts
@@ -1,0 +1,46 @@
+import { Element, Root } from "hast";
+import { visit } from "unist-util-visit";
+import { Plugin } from "unified";
+import { isMarkdownVFile } from "./types";
+import { dirname, join, relative } from "path";
+import fs from "fs/promises";
+import { logError } from "./logger";
+
+/**
+ * Transform links to relative files (e.g. [find the slides here](./slides.pptx)) that are placed
+ * adjacent to the post markdown so that they resolve to the hosted content dir.
+ */
+export const rehypeRelativePaths: Plugin<[], Root> = () => {
+	return async (tree, vfile) => {
+		let path = "";
+		if (isMarkdownVFile(vfile)) {
+			const file = relative(process.cwd(), vfile.data.file);
+			path = dirname(file);
+		}
+
+		async function visitor(node: Element) {
+			const href = node.properties!.href as string;
+			// If the URL is already parsed or absolute, skip it
+			if (URL.canParse(href) || href.startsWith("#") || href.startsWith("/"))
+				return;
+
+			// Attempt to locate the file in FS
+			const fileUrl = join(path, href);
+			const fileStat = await fs.stat(fileUrl).catch(() => undefined);
+			if (!fileStat?.isFile) {
+				logError(vfile, node, "Unable to locate relative file:", fileUrl);
+				return;
+			}
+
+			// If the file is successfully located, transform to an absolute path
+			node.properties!.href = "/" + fileUrl;
+		}
+
+		const promises: Array<Promise<void>> = [];
+		visit(tree, { type: "element", tagName: "a" }, (node) => {
+			promises.push(visitor(node));
+		});
+		await Promise.all(promises);
+		return tree;
+	};
+};


### PR DESCRIPTION
- Fixes misformatted links in ffg-ecosystem-styling
- Removes an empty link from ffg-fundamentals-intro-to-components
- Renames `vitejs.dev` -> `vite.dev`
- Changes any relative post links to absolute `/posts` paths
- Changes rehype-absolute-paths to use the content path as the base URL (handles links to adjacent files, which fixes `./slides.pptx` in angular-templates-start-to-source)