### PR TITLE
Fix search not persisting author filters on mobile

### DIFF
--- a/src/views/search/components/filter-display.tsx
+++ b/src/views/search/components/filter-display.tsx
@@ -8,6 +8,7 @@ import { FilterSidebar } from "./filter-sidebar";
 import tagsObj from "../../../../content/data/tags.json";
 import { SortType } from "src/views/search/search";
 import { ExtendedTag, ExtendedUnicorn } from "./types";
+import { FilterState } from "../use-filter-state";
 
 const tagsMap: Map<string, TagInfo> = new Map(Object.entries(tagsObj));
 
@@ -15,10 +16,7 @@ interface FilterDisplayProps {
 	tagCounts: Record<string, number>;
 	authorCounts: Record<string, number>;
 	peopleMap: Map<string, PersonInfo>;
-	selectedTags: string[];
-	setSelectedTags: (tags: string[]) => void;
-	selectedAuthorIds: string[];
-	setSelectedAuthorIds: (authors: string[]) => void;
+	filterState: FilterState,
 	sort: SortType;
 	setSort: (sortBy: SortType) => void;
 	desktopStyle?: CSSProperties;
@@ -36,10 +34,7 @@ export const FilterDisplay = ({
 	peopleMap,
 	sort,
 	setSort,
-	selectedAuthorIds,
-	selectedTags,
-	setSelectedAuthorIds,
-	setSelectedTags,
+	filterState,
 	desktopStyle,
 	isFilterDialogOpen,
 	isHybridSearch,
@@ -51,7 +46,7 @@ export const FilterDisplay = ({
 	const tags: ExtendedTag[] = useMemo(() => {
 		const totalEntries = {
 			// Ensure that selected tags are included in the filter list
-			...Object.fromEntries(selectedTags.map((tag) => [tag, 0])),
+			...Object.fromEntries(filterState.tags.map((tag) => [tag, 0])),
 			...tagCounts,
 		};
 
@@ -71,7 +66,7 @@ export const FilterDisplay = ({
 	const authors: ExtendedUnicorn[] = useMemo(() => {
 		const totalEntries = {
 			// Ensure that selected authors are included in the filter list
-			...Object.fromEntries(selectedAuthorIds.map((author) => [author, 0])),
+			...Object.fromEntries(filterState.authors.map((author) => [author, 0])),
 			...authorCounts,
 		};
 
@@ -87,24 +82,6 @@ export const FilterDisplay = ({
 			.sort((a, b) => a.name.localeCompare(b.name));
 	}, [authorCounts, peopleMap]);
 
-	const onSelectedAuthorChange = (id: string) => {
-		const isPresent = selectedAuthorIds.includes(id);
-		if (isPresent) {
-			setSelectedAuthorIds(selectedAuthorIds.filter((author) => author !== id));
-		} else {
-			setSelectedAuthorIds([...selectedAuthorIds, id]);
-		}
-	};
-
-	const onTagsChange = (id: string) => {
-		const isPresent = selectedTags.includes(id);
-		if (isPresent) {
-			setSelectedTags(selectedTags.filter((tag) => tag !== id));
-		} else {
-			setSelectedTags([...selectedTags, id]);
-		}
-	};
-
 	const windowSize = useWindowSize();
 
 	const shouldShowDialog = windowSize.width <= tabletLarge;
@@ -114,16 +91,15 @@ export const FilterDisplay = ({
 			<FilterDialog
 				isOpen={isFilterDialogOpen}
 				onClose={(props) => {
-					const { selectedAuthorIds: innerAuthorIds, selectedTags: innerTags } =
-						props;
-					setSelectedAuthorIds(innerAuthorIds);
-					setSelectedTags(innerTags);
+					filterState.setFilters({
+						tags: props.selectedTags,
+						authors: props.selectedAuthorIds,
+					});
 					setFilterIsDialogOpen(false);
 				}}
 				tags={tags}
 				authors={authors}
-				selectedAuthorIds={selectedAuthorIds}
-				selectedTags={selectedTags}
+				filterState={filterState}
 				isHybridSearch={isHybridSearch}
 			/>
 		);
@@ -133,15 +109,10 @@ export const FilterDisplay = ({
 		<FilterSidebar
 			sort={sort}
 			setSort={setSort}
-			selectedAuthorIds={selectedAuthorIds}
-			selectedTags={selectedTags}
-			setSelectedAuthorIds={setSelectedAuthorIds}
-			setSelectedTags={setSelectedTags}
 			desktopStyle={desktopStyle}
 			tags={tags}
 			authors={authors}
-			onSelectedAuthorChange={onSelectedAuthorChange}
-			onTagsChange={onTagsChange}
+			filterState={filterState}
 			searchString={searchString}
 			setContentToDisplay={setContentToDisplay}
 			contentToDisplay={contentToDisplay}

--- a/src/views/search/components/filter-section-item.tsx
+++ b/src/views/search/components/filter-section-item.tsx
@@ -11,7 +11,7 @@ interface FilterSectionItemProps {
 	count: number;
 	selected: boolean;
 	isHybridSearch: boolean;
-	onChange: () => void;
+	onChange: (selected: boolean) => void;
 }
 
 export const FilterSectionItem = ({

--- a/src/views/search/components/filter-sidebar.tsx
+++ b/src/views/search/components/filter-sidebar.tsx
@@ -8,19 +8,15 @@ import { ExtendedTag, ExtendedUnicorn } from "./types";
 import { SortType } from "src/views/search/search";
 import { DEFAULT_TAG_EMOJI } from "./constants";
 import { FilterSidebarControls } from "./filter-sidebar-controls";
+import { FilterState } from "../use-filter-state";
 
 interface FilterSidebar {
 	desktopStyle?: CSSProperties;
-	selectedTags: string[];
-	setSelectedTags: (tags: string[]) => void;
-	selectedAuthorIds: string[];
-	setSelectedAuthorIds: (authors: string[]) => void;
 	sort: SortType;
 	setSort: (sortBy: SortType) => void;
 	tags: ExtendedTag[];
 	authors: ExtendedUnicorn[];
-	onSelectedAuthorChange: (authorId: string) => void;
-	onTagsChange: (tag: string) => void;
+	filterState: FilterState;
 	searchString: string;
 	setContentToDisplay: (content: "all" | "articles" | "collections") => void;
 	contentToDisplay: "all" | "articles" | "collections";
@@ -30,15 +26,10 @@ interface FilterSidebar {
 export const FilterSidebar = ({
 	sort,
 	setSort,
-	selectedAuthorIds,
-	selectedTags,
-	setSelectedAuthorIds,
-	setSelectedTags,
 	desktopStyle,
-	onSelectedAuthorChange,
-	onTagsChange,
 	authors,
 	tags,
+	filterState,
 	searchString,
 	setContentToDisplay,
 	contentToDisplay,
@@ -74,8 +65,8 @@ export const FilterSidebar = ({
 			<FilterSection
 				title={"Tag"}
 				data-testid="tag-filter-section-sidebar"
-				selectedNumber={selectedTags.length}
-				onClear={() => setSelectedTags([])}
+				selectedNumber={filterState.tags.length}
+				onClear={() => filterState.setTags([])}
 			>
 				{tags.map((tag, i) => {
 					return (
@@ -93,8 +84,8 @@ export const FilterSidebar = ({
 								)
 							}
 							label={tag?.displayName ?? tag.tag}
-							selected={selectedTags.includes(tag.tag)}
-							onChange={() => onTagsChange(tag.tag)}
+							selected={filterState.tags.includes(tag.tag)}
+							onChange={(selected) => filterState.onTagChange(tag.tag, selected)}
 							isHybridSearch={isHybridSearch}
 						/>
 					);
@@ -103,8 +94,8 @@ export const FilterSidebar = ({
 			<FilterSection
 				title={"Author"}
 				data-testid="author-filter-section-sidebar"
-				selectedNumber={selectedAuthorIds.length}
-				onClear={() => setSelectedAuthorIds([])}
+				selectedNumber={filterState.authors.length}
+				onClear={() => filterState.setAuthors([])}
 			>
 				{authors.map((author) => {
 					return (
@@ -120,8 +111,8 @@ export const FilterSidebar = ({
 								/>
 							}
 							label={author.name}
-							selected={selectedAuthorIds.includes(author.id)}
-							onChange={() => onSelectedAuthorChange(author.id)}
+							selected={filterState.authors.includes(author.id)}
+							onChange={(selected) => filterState.onAuthorChange(author.id, selected)}
 							isHybridSearch={isHybridSearch}
 						/>
 					);

--- a/src/views/search/use-filter-state.ts
+++ b/src/views/search/use-filter-state.ts
@@ -1,0 +1,51 @@
+import { useCallback, useMemo, useState } from "preact/hooks";
+
+interface FilterStateParams {
+	tags: string[];
+	authors: string[];
+	setTags(tags: string[]): void;
+	setAuthors(authors: string[]): void;
+	setFilters?(filters: Pick<FilterStateParams, "tags" | "authors">): void;
+}
+
+export interface FilterState extends Required<FilterStateParams> {
+	onTagChange(tag: string, selected: boolean): void;
+	onAuthorChange(author: string, selected: boolean): void;
+}
+
+export function useFilterState(params: FilterStateParams): FilterState {
+	const onTagChange = useCallback(
+		(id: string, selected: boolean) => {
+			if (selected) {
+				params.setTags([...params.tags, id]);
+			} else {
+				params.setTags(params.tags.filter((tag) => tag !== id));
+			}
+		},
+		[params.tags, params.setTags],
+	);
+
+	const onAuthorChange = useCallback(
+		(id: string, selected: boolean) => {
+			if (selected) {
+				params.setAuthors([...params.authors, id]);
+			} else {
+				params.setAuthors(params.authors.filter((author) => author !== id));
+			}
+		},
+		[params.authors, params.setAuthors],
+	);
+
+	return useMemo<FilterState>(
+		() => ({
+			setFilters(filters) {
+				params.setTags(filters.tags);
+				params.setAuthors(filters.authors);
+			},
+			...params,
+			onTagChange,
+			onAuthorChange,
+		}),
+		[params.setFilters, onTagChange, onAuthorChange],
+	);
+}


### PR DESCRIPTION
Moved some duplicate logic to a `useFilterState` hook.

The key change is `setFilters()` accepting both authors and tags in one call. `setSelectedAuthorIds` and `setSelectedTags` were previously called sequentially in the `onClose` callback, which get debounced by `setQuery` - so the first is never reflected in the final state.

`search-page.tsx` provides an implementation for `setFilters` which avoids this issue.