### PR TITLE
Improve fullstack dev environment

### DIFF
--- a/CONTRIBUTING.code.md
+++ b/CONTRIBUTING.code.md
@@ -48,6 +48,19 @@ Once you have everything installed, you'll have access to several helpful comman
 
 - `pnpm test`: Runs our test suite to make sure everything is working correctly.
 
+### Setting Up Local Backend Services (Optional)
+
+To test the interaction of the backend with the frontend you need to set up the backend services:
+
+1. Clone or fork the hoof repository: `git clone https://github.com/playfulprogramming/hoof`
+2. Follow the hoof README to get your services running
+3. Double check your env variables in `src/environments/local.env`
+4. Use these to test locally:
+   - Run `pnpm dev:local` to run dev with local environment variables
+   - Run `pnpm build:local` to build with local environment variables
+      - The first build will take +40 minutes to cache in the DB locally. We may want a Seed Script in the future.
+   - Run `pnpm preview` to preview the built app
+
 ## Example workflow
 
 A typical development workflow looks like this:

--- a/package.json
+++ b/package.json
@@ -22,11 +22,12 @@
 	"scripts": {
 		"debug": "env-cmd -f ./src/environments/debug.env astro dev",
 		"dev": "env-cmd -f ./src/environments/dev.env astro dev",
+		"dev:local": "env-cmd -f ./src/environments/local.env astro dev",
 		"start": "astro dev",
 		"build": "astro build",
 		"build:debug": "env-cmd -f ./src/environments/debug.env astro build",
-		"build:dev": "env-cmd -f ./src/environments/dev.env astro build",
 		"build-beta": "env-cmd -f ./src/environments/beta.env pnpm run build",
+		"build:local": "env-cmd -f ./src/environments/local.env astro build",
 		"preview": "astro preview",
 		"format": "prettier -w . --cache --plugin-search-dir=.",
 		"lint": "eslint \"src/**/*.{js,ts,astro}\" \"*.{js,ts}\"",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"start": "astro dev",
 		"build": "astro build",
 		"build:debug": "env-cmd -f ./src/environments/debug.env astro build",
+		"build:dev": "env-cmd -f ./src/environments/dev.env astro build",
 		"build-beta": "env-cmd -f ./src/environments/beta.env pnpm run build",
 		"preview": "astro preview",
 		"format": "prettier -w . --cache --plugin-search-dir=.",

--- a/src/constants/site-config.ts
+++ b/src/constants/site-config.ts
@@ -33,7 +33,7 @@ export const siteMetadata = {
 	title: `Playful Programming`,
 	description: `Learning programming from magically majestic words. A place to learn about all sorts of programming topics from entry-level concepts to advanced abstractions`,
 	siteUrl,
-	repoPath: "playfulprogramming/playfulprogramming",
+	repoPath: env("REPO_PATH") || "playfulprogramming/playfulprogramming",
 	relativeToPosts: "/content/blog",
 	keywords:
 		"programming,development,mobile,web,game,playful,software engineering,javascript,angular,react,computer science",

--- a/src/environments/dev.env
+++ b/src/environments/dev.env
@@ -1,2 +1,3 @@
 BUILD_ENV="development"
 NODE_OPTIONS="--max-old-space-size=8192"
+# HOOF_URL=http://localhost:3000

--- a/src/environments/dev.env
+++ b/src/environments/dev.env
@@ -1,4 +1,2 @@
 BUILD_ENV="development"
 NODE_OPTIONS="--max-old-space-size=8192"
-REPO_PATH=mikecebul/playfulprogramming
-HOOF_URL=http://localhost:3000

--- a/src/environments/dev.env
+++ b/src/environments/dev.env
@@ -1,3 +1,4 @@
 BUILD_ENV="development"
 NODE_OPTIONS="--max-old-space-size=8192"
-# HOOF_URL=http://localhost:3000
+REPO_PATH=mikecebul/playfulprogramming
+HOOF_URL=http://localhost:3000

--- a/src/environments/local.env
+++ b/src/environments/local.env
@@ -3,4 +3,4 @@ NODE_OPTIONS="--max-old-space-size=8192"
 HOOF_URL=http://localhost:3000
 
 # For functional stackblitz iframes add your Github Repo name for the path
-REPO_PATH=yourname/playfulprogramming
+REPO_PATH=mikecebul/playfulprogramming

--- a/src/environments/local.env
+++ b/src/environments/local.env
@@ -1,0 +1,6 @@
+BUILD_ENV="development"
+NODE_OPTIONS="--max-old-space-size=8192"
+HOOF_URL=http://localhost:3000
+
+# For functional stackblitz iframes add your Github Repo name for the path
+REPO_PATH=yourname/playfulprogramming

--- a/src/utils/get-picture.ts
+++ b/src/utils/get-picture.ts
@@ -47,8 +47,8 @@ if (!isDev && !cloudinaryCloudName)
 	console.error("missing public variable CLOUDINARY_CLOUD_NAME");
 
 function getSource(src: string, width: number, getFormat: string) {
-	if (isDev) {
-		// If the dev server is running, we can use the /_image endpoint
+	if (isDev || !cloudinaryCloudName) {
+		// If the dev server is running or cloudinary isn't configured, use the /_image endpoint
 		return `/_image?${new URLSearchParams({
 			href: src,
 			w: String(width),

--- a/src/utils/hoof/get-url-metadata.ts
+++ b/src/utils/hoof/get-url-metadata.ts
@@ -20,12 +20,15 @@ interface UrlMetadataResponse {
 export async function getUrlMetadata(
 	url: string,
 ): Promise<UrlMetadataResponse> {
+	// Normalize branch to 'main' for cache hits
+	const normalizedUrl = url.replace(/\/tree\/[^\/]+\//, "/tree/main/");
+
 	for (let retries = 0; retries < 10; retries++) {
 		await setTimeout(Math.pow(retries, 2) * 1000);
 
 		const req = await client
 			.POST("/tasks/url-metadata", {
-				body: { url },
+				body: { url: normalizedUrl },
 			})
 			.catch((e) => ({ exception: e }) as const);
 

--- a/src/utils/hoof/get-url-metadata.ts
+++ b/src/utils/hoof/get-url-metadata.ts
@@ -20,15 +20,12 @@ interface UrlMetadataResponse {
 export async function getUrlMetadata(
 	url: string,
 ): Promise<UrlMetadataResponse> {
-	// Normalize branch to 'main' for cache hits
-	const normalizedUrl = url.replace(/\/tree\/[^\/]+\//, "/tree/main/");
-
 	for (let retries = 0; retries < 10; retries++) {
 		await setTimeout(Math.pow(retries, 2) * 1000);
 
 		const req = await client
 			.POST("/tasks/url-metadata", {
-				body: { url: normalizedUrl },
+				body: { url },
 			})
 			.catch((e) => ({ exception: e }) as const);
 


### PR DESCRIPTION
## Summary
If testing out builds locally is required then we need to run against a local development instance of Hoof. To accomplish this I 

- created a local.env file 
- added a REPO_PATH var to test out Stackblitz iframes in dev
- created dev:local and build:local scripts using those env vars
- added a fallback in production to use local files for pictures if there is no cloudinaryCloudName
- added documentation on setting this up

This allows to fully test out the Astro frontend. 

## Issues
Building the first time took me 42 minutes on my M1 Macbook. Once cached it build in one minute. We should look into creating a seed script in the future.