### PR TITLE
Upgrade node version to 22.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
 		"url": "git+https://github.com/playfulprogramming/playfulprogramming.git"
 	},
 	"packageManager": "pnpm@9.4.0",
+	"engines": {
+		"node": "22.x"
+	},
 	"scripts": {
 		"debug": "env-cmd -f ./src/environments/debug.env astro dev",
 		"dev": "env-cmd -f ./src/environments/dev.env astro dev",


### PR DESCRIPTION
Updates the [node version used by Vercel](https://vercel.com/docs/functions/runtimes/node-js/node-js-versions) to 22.x