### PR TITLE
Migrate env variables to `astro:env`

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,17 +1,19 @@
 import { defineConfig, envField } from "astro/config";
 import preact from "@astrojs/preact";
 import icon from "astro-icon";
-import { siteUrl } from "./src/constants/site-config";
 import vercel from "@astrojs/vercel";
 import symlink from "symlink-dir";
 import * as path from "path";
-import { SUPPORTED_IMAGE_SIZES } from "./src/utils/get-picture";
+import { SUPPORTED_IMAGE_SIZES } from "./src/utils/get-picture/constants";
 import { AstroUserConfig } from "astro";
 
 await symlink(path.resolve("content"), path.resolve("public/content"));
 
 export default defineConfig({
-	site: siteUrl,
+	site:
+		import.meta.env.SITE_URL ??
+		import.meta.env.VERCEL_URL ??
+		"https://playfulprogramming.com",
 	adapter: vercel({
 		// Uses Vercel's Image Optimization API: https://vercel.com/docs/image-optimization
 		imageService: true,
@@ -26,24 +28,24 @@ export default defineConfig({
 	env: {
 		schema: {
 			BUILD_MODE: envField.enum({
-				context: "server",
+				context: "client",
 				access: "public",
 				values: ["development", "beta", "production"],
 				optional: true,
 				default: "development",
 			}),
 			SITE_URL: envField.string({
-				context: "server",
+				context: "client",
 				access: "public",
 				optional: true,
 			}),
 			VERCEL_URL: envField.string({
-				context: "server",
+				context: "client",
 				access: "public",
 				optional: true,
 			}),
 			PUBLIC_CLOUDINARY_CLOUD_NAME: envField.string({
-				context: "server",
+				context: "client",
 				access: "public",
 				optional: true,
 			}),

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "astro/config";
+import { defineConfig, envField } from "astro/config";
 import preact from "@astrojs/preact";
 import sitemap from "@astrojs/sitemap";
 import icon from "astro-icon";
@@ -68,6 +68,48 @@ export default defineConfig({
 			},
 		}),
 	],
+	env: {
+		schema: {
+			BUILD_MODE: envField.enum({
+				context: "server",
+				access: "public",
+				values: ["development", "beta", "production"],
+				optional: true,
+				default: "development",
+			}),
+			SITE_URL: envField.string({
+				context: "server",
+				access: "public",
+				optional: true,
+			}),
+			VERCEL_URL: envField.string({
+				context: "server",
+				access: "public",
+				optional: true,
+			}),
+			PUBLIC_CLOUDINARY_CLOUD_NAME: envField.string({
+				context: "server",
+				access: "public",
+				optional: true,
+			}),
+			HOOF_AUTH_TOKEN: envField.string({
+				context: "server",
+				access: "secret",
+				optional: true,
+			}),
+			HOOF_URL: envField.string({
+				context: "server",
+				access: "public",
+				optional: true,
+				default: "https://hoof.playfulprogramming.com",
+			}),
+			GITHUB_TOKEN: envField.string({
+				context: "server",
+				access: "secret",
+				optional: true,
+			}),
+		},
+	},
 	server: {
 		headers: {
 			["Cross-Origin-Embedder-Policy"]: "require-corp",

--- a/src/constants/site-config.ts
+++ b/src/constants/site-config.ts
@@ -1,4 +1,4 @@
-import { SITE_URL, VERCEL_URL, BUILD_MODE } from "astro:env/server";
+import { BUILD_MODE, SITE_URL, VERCEL_URL } from "astro:env/client";
 
 export const buildMode = BUILD_MODE;
 export const siteUrl = (() => {
@@ -11,7 +11,7 @@ export const siteUrl = (() => {
 			case "production":
 				return "https://playfulprogramming.com";
 			case "development":
-				return "http://localhost:3000";
+				return "http://localhost:4321";
 			default:
 				return "https://beta.playfulprogramming.com";
 		}

--- a/src/constants/site-config.ts
+++ b/src/constants/site-config.ts
@@ -1,16 +1,8 @@
-export function env<K extends keyof NodeJS.ProcessEnv>(
-	name: K,
-): NodeJS.ProcessEnv[K] {
-	if (typeof process !== "undefined") {
-		return process.env[name];
-	} else {
-		return import.meta.env[name];
-	}
-}
+import { SITE_URL, VERCEL_URL, BUILD_MODE } from "astro:env/server";
 
-export const buildMode = env("BUILD_ENV") || "production";
+export const buildMode = BUILD_MODE;
 export const siteUrl = (() => {
-	let siteUrl = env("SITE_URL") || env("VERCEL_URL") || "";
+	let siteUrl = SITE_URL || VERCEL_URL || "";
 
 	if (siteUrl && !siteUrl.startsWith("http")) siteUrl = `https://${siteUrl}`;
 
@@ -41,7 +33,3 @@ export const siteMetadata = {
 		"programming,development,mobile,web,game,playful,software engineering,javascript,angular,react,computer science",
 	twitterHandle: "@playful_program",
 };
-
-export const cloudinaryCloudName = env("PUBLIC_CLOUDINARY_CLOUD_NAME");
-
-export const hoofUrl = env("HOOF_URL") || "https://hoof.playfulprogramming.com";

--- a/src/types/modules/env.d.ts
+++ b/src/types/modules/env.d.ts
@@ -2,13 +2,6 @@ declare global {
 	namespace NodeJS {
 		interface ProcessEnv {
 			CI?: string;
-			BUILD_ENV: "development" | "beta" | "production";
-			SITE_URL?: string;
-			VERCEL_URL?: string;
-
-			HOOF_URL?: string;
-			GITHUB_TOKEN?: string;
-			PUBLIC_CLOUDINARY_CLOUD_NAME?: string;
 			ORAMA_PRIVATE_API_KEY?: string;
 		}
 	}

--- a/src/utils/achievements/github.ts
+++ b/src/utils/achievements/github.ts
@@ -1,11 +1,12 @@
 import { Octokit } from "octokit";
 import { GraphqlResponseError } from "@octokit/graphql";
 import { getPeopleByLang } from "utils/api";
+import { GITHUB_TOKEN } from "astro:env/server";
 
 const octokit =
-	typeof process.env.GITHUB_TOKEN !== "undefined"
+	typeof GITHUB_TOKEN !== "undefined"
 		? new Octokit({
-				auth: process.env.GITHUB_TOKEN,
+				auth: GITHUB_TOKEN,
 			})
 		: undefined;
 

--- a/src/utils/get-picture.ts
+++ b/src/utils/get-picture.ts
@@ -1,6 +1,7 @@
 import type { JSX } from "preact";
 import type { ImageMetadata } from "astro";
-import { siteUrl, cloudinaryCloudName } from "../constants/site-config";
+import { siteUrl } from "../constants/site-config";
+import { BUILD_MODE, PUBLIC_CLOUDINARY_CLOUD_NAME } from "astro:env/server";
 
 export interface GetPictureSizes {
 	[size: number]: {
@@ -41,13 +42,14 @@ function getSupportedWidth(width: number) {
 	);
 }
 
-const isDev = Boolean(import.meta.env?.DEV);
+const isDev = BUILD_MODE == "development";
 
-if (!isDev && !cloudinaryCloudName)
-	console.error("missing public variable CLOUDINARY_CLOUD_NAME");
+if (!isDev && !PUBLIC_CLOUDINARY_CLOUD_NAME) {
+	throw new Error("missing env variable PUBLIC_CLOUDINARY_CLOUD_NAME");
+}
 
 function getSource(src: string, width: number, getFormat: string) {
-	if (isDev || !cloudinaryCloudName) {
+	if (isDev || !PUBLIC_CLOUDINARY_CLOUD_NAME) {
 		// If the dev server is running or cloudinary isn't configured, use the /_image endpoint
 		return `/_image?${new URLSearchParams({
 			href: src,
@@ -57,7 +59,7 @@ function getSource(src: string, width: number, getFormat: string) {
 	} else {
 		// If in production use cloudinary's fetch
 		const domainUrl = new URL(src, siteUrl);
-		return `https://res.cloudinary.com/${cloudinaryCloudName}/image/fetch/w_${width},f_${getFormat},q_auto/${encodeURIComponent(domainUrl.toString())}`;
+		return `https://res.cloudinary.com/${PUBLIC_CLOUDINARY_CLOUD_NAME}/image/fetch/w_${width},f_${getFormat},q_auto/${encodeURIComponent(domainUrl.toString())}`;
 	}
 }
 

--- a/src/utils/get-picture/constants.ts
+++ b/src/utils/get-picture/constants.ts
@@ -1,0 +1,3 @@
+export const SUPPORTED_IMAGE_SIZES = [
+	24, 48, 72, 96, 160, 192, 480, 512, 896, 1080, 1200,
+];

--- a/src/utils/get-picture/index.ts
+++ b/src/utils/get-picture/index.ts
@@ -1,7 +1,8 @@
 import type { JSX } from "preact";
 import type { ImageMetadata } from "astro";
-import { siteUrl } from "../constants/site-config";
-import { BUILD_MODE, PUBLIC_CLOUDINARY_CLOUD_NAME } from "astro:env/server";
+import { siteUrl } from "../../constants/site-config";
+import { BUILD_MODE, PUBLIC_CLOUDINARY_CLOUD_NAME } from "astro:env/client";
+import { SUPPORTED_IMAGE_SIZES } from "./constants";
 
 export interface GetPictureSizes {
 	[size: number]: {
@@ -29,10 +30,6 @@ export interface GetPictureResult {
 	image: JSX.ImgHTMLAttributes;
 	sources: JSX.SourceHTMLAttributes[];
 }
-
-export const SUPPORTED_IMAGE_SIZES = [
-	24, 48, 72, 96, 160, 192, 480, 512, 896, 1080, 1200,
-];
 
 function getSupportedWidth(width: number) {
 	// Find the closest supported image size for a given width

--- a/src/utils/hoof/client.ts
+++ b/src/utils/hoof/client.ts
@@ -1,6 +1,7 @@
 import createClient from "openapi-fetch";
 import type { paths } from "./schema";
-import { BUILD_MODE, HOOF_URL, HOOF_AUTH_TOKEN } from "astro:env/server";
+import { BUILD_MODE } from "astro:env/client";
+import { HOOF_URL, HOOF_AUTH_TOKEN } from "astro:env/server";
 
 if (BUILD_MODE === "production" && !HOOF_AUTH_TOKEN) {
 	throw new Error("Environment variable HOOF_AUTH_TOKEN is missing!");

--- a/src/utils/hoof/client.ts
+++ b/src/utils/hoof/client.ts
@@ -1,10 +1,12 @@
 import createClient from "openapi-fetch";
 import type { paths } from "./schema";
-import { env, hoofUrl } from "../../constants/site-config";
+import { BUILD_MODE, HOOF_URL, HOOF_AUTH_TOKEN } from "astro:env/server";
 
-const HOOF_AUTH_TOKEN = env("HOOF_AUTH_TOKEN");
+if (BUILD_MODE === "production" && !HOOF_AUTH_TOKEN) {
+	throw new Error("Environment variable HOOF_AUTH_TOKEN is missing!");
+}
 
 export const client = createClient<paths>({
-	baseUrl: hoofUrl,
+	baseUrl: HOOF_URL,
 	...(HOOF_AUTH_TOKEN && { headers: { "x-hoof-auth-token": HOOF_AUTH_TOKEN } }),
 });


### PR DESCRIPTION
Uses the `astro:env` package for environment variables to prevent import.meta.env/process.env inconsistency & fix missing env variables in builds.

https://docs.astro.build/en/reference/modules/astro-env/