### PR TITLE
Fix layout width issues

### DIFF
--- a/src/views/collections/framework-field-guide/components/your-guide-metrics.module.scss
+++ b/src/views/collections/framework-field-guide/components/your-guide-metrics.module.scss
@@ -8,8 +8,13 @@
 	padding: 0;
 	padding-bottom: var(--spc-6x);
 	list-style-type: none;
-	grid-template-columns: repeat(3, 1fr);
-	grid-template-rows: repeat(2, 1fr);
+	grid-template-columns: repeat(2, 1fr);
+	grid-template-rows: repeat(3, 1fr);
+
+	@include from($tablet) {
+		grid-template-columns: repeat(3, 1fr);
+		grid-template-rows: repeat(2, 1fr);
+	}
 
 	@include from($desktop) {
 		grid-template-columns: repeat(6, 1fr);
@@ -47,8 +52,7 @@
 	top: calc(50% + -0.5rem);
 	left: 50%;
 	transform: translate(-50%, -50%);
-	font-family:
-		"Plus Jakarta Sans", "Plus Jakarta Sans-fallback",
+	font-family: "Plus Jakarta Sans", "Plus Jakarta Sans-fallback",
 		"Plus Jakarta Sans-fallback2", sans-serif;
 	font-style: normal;
 	font-weight: 500;

--- a/src/views/collections/framework-field-guide/segments/adventure-continues.module.scss
+++ b/src/views/collections/framework-field-guide/segments/adventure-continues.module.scss
@@ -22,11 +22,15 @@
 	padding: 0;
 	list-style: none;
 	display: grid;
-	grid-template-columns: repeat(2, 1fr);
+	grid-template-columns: repeat(1, 1fr);
 	gap: var(--grid-gap);
 
-	.gridItem:last-child {
-		grid-column: span 2;
+	@include from($tablet) {
+		grid-template-columns: repeat(2, 1fr);
+
+		.gridItem:last-child {
+			grid-column: span 2;
+		}
 	}
 
 	@include from($desktop) {


### PR DESCRIPTION
Fixes the issue where on smaller mobile devices, there would be a space to the right of the page that looks like a margin. See #1379

I was not able to replicate the bug on my device because i have a larger screen than the iPhone 12 @20jasper found the bug on, but I did using the inspector. However I had to make the screen a lot smaller (>320 px) to get the same effect.

@20jasper, can you confirm that the issue is fixed on the device? The issue here is that some elements (@crutchcorn metrics & the section on the 'the adventure continues') were wider than the available width.