### PR TITLE
Create Dockerfile & Fly.io service

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.vercel
+.astro
+.vscode
+node_modules
+dist
+public/content

--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -1,0 +1,23 @@
+name: Fly Deploy
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: deploy-group # ensure only one deploy action runs at a time
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy app
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: superfly/flyctl-actions/setup-flyctl@1.5
+      - name: Deploy App
+        run: flyctl console --dockerfile Dockerfile.builder -C "/srv/deploy.sh" --env "FLY_API_TOKEN=$FLY_API_TOKEN"
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_WEB_DEPLOY_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM node:22-alpine3.22 AS builder
+
+# Create app directory
+WORKDIR /var/app
+
+# Prepare pnpm according to the root package.json
+COPY package.json .
+RUN corepack enable
+RUN corepack install
+
+# Install dependencies with pnpm
+COPY pnpm-lock.yaml .
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store,sharing=locked pnpm install
+
+# Copy and build the app
+COPY --parents assets content public src astro.config.ts tsconfig.json .env .
+
+# Define build arguments
+ARG GIT_COMMIT_REF
+ARG PUBLIC_CLOUDINARY_CLOUD_NAME
+ARG ENABLE_DISCOVERABILITY
+ARG SITE_URL
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+	--mount=type=secret,id=HOOF_AUTH_TOKEN \
+	GITHUB_TOKEN=$(cat /run/secrets/GITHUB_TOKEN) \
+	HOOF_AUTH_TOKEN=$(cat /run/secrets/HOOF_AUTH_TOKEN) \
+	GIT_COMMIT_REF=$GIT_COMMIT_REF \
+	PUBLIC_CLOUDINARY_CLOUD_NAME=$PUBLIC_CLOUDINARY_CLOUD_NAME \
+	ENABLE_DISCOVERABILITY=$ENABLE_DISCOVERABILITY \
+	SITE_URL=$SITE_URL \
+	BUILD_ENV=production \
+	ASTRO_TELEMETRY_DISABLED=1 \
+	pnpm build
+
+FROM nginx:1.29.1-alpine3.22-slim
+
+# Copy the project nginx configuration
+COPY ./nginx.conf /etc/nginx/conf.d/default.conf
+# Copy output HTML from the builder
+COPY --from=builder /var/app/dist /usr/share/nginx/html
+# Test the nginx config to make sure it works
+RUN nginx -t

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1
+FROM flyio/flyctl:latest as flyio
+FROM alpine:3.22
+
+RUN apk --update add ca-certificates jq bash
+
+COPY <<"EOF" /srv/deploy.sh
+#!/bin/bash
+deploy=(flyctl deploy)
+
+while read -r secret; do
+  deploy+=(--build-secret "${secret}=${!secret}")
+done < <(flyctl secrets list --json | jq -r ".[].Name")
+
+${deploy[@]}
+EOF
+
+RUN chmod +x /srv/deploy.sh
+
+COPY --from=flyio /flyctl /usr/bin
+
+WORKDIR /build
+COPY . .
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+name: playful-programming-web
+
+services:
+  web:
+    env_file: .env
+    build:
+      context: .
+      args:
+        SITE_URL: http://localhost:8080
+        ENABLE_DISCOVERABILITY: false
+        GIT_COMMIT_REF: main
+        PUBLIC_CLOUDINARY_CLOUD_NAME: $PUBLIC_CLOUDINARY_CLOUD_NAME
+      secrets:
+        - GITHUB_TOKEN
+        - HOOF_AUTH_TOKEN
+    ports:
+      - "8080:80"
+    develop:
+      watch:
+        - path: .
+          action: rebuild
+
+secrets:
+  GITHUB_TOKEN:
+    environment: GITHUB_TOKEN
+  HOOF_AUTH_TOKEN:
+    environment: HOOF_AUTH_TOKEN

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,36 @@
+# fly.toml app configuration file generated for playful-web on 2025-09-27T10:47:33-04:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = 'playful-web'
+primary_region = 'sjc'
+
+[build]
+  dockerfile = 'Dockerfile'
+
+  [build.args]
+    ENABLE_DISCOVERABILITY = 'false'
+    GIT_COMMIT_REF = 'main'
+    PUBLIC_CLOUDINARY_CLOUD_NAME = 'dssjarn7f'
+    SITE_URL = 'https://playfulprogramming.com'
+
+[deploy]
+  strategy = 'bluegreen'
+
+[http_service]
+  internal_port = 80
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 1
+
+  [[http_service.checks]]
+    interval = '30s'
+    timeout = '5s'
+    grace_period = '10s'
+    method = 'GET'
+    path = '/'
+
+[[vm]]
+  size = 'shared-cpu-1x'

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,36 @@
+server {
+    listen 80;
+	access_log off;
+    root /usr/share/nginx/html;
+    index index.html;
+    etag on;
+
+	# HTTP compression
+	gzip on;
+	gzip_vary on;
+	gzip_proxied any;
+	gzip_comp_level 6;
+	gzip_buffers 16 8k;
+	gzip_http_version 1.1;
+	gzip_min_length 256;
+
+	error_page 404 /404.html;
+	try_files $uri/index.html $uri/ $uri =404;
+	absolute_redirect off;
+
+	add_header Cache-Control "public, max-age=0, must-revalidate";
+	add_header Cross-Origin-Embedder-Policy "require-corp";
+	add_header Cross-Origin-Opener-Policy "same-origin";
+
+    location * {}
+
+	# Cache Astro computed assets for 1d
+    location /_astro/ {
+        add_header Cache-Control "public, max-age=86400, immutable";
+    }
+
+    # Cache large or static assets for 1yr
+    location ~* \.(png|jpg|jpeg|gif|mp4|ttf|woff|woff2)$ {
+        add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+}

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
 		"@remark-embedder/transformer-oembed": "^5.0.1",
 		"@shikijs/rehype": "^3.12.2",
 		"@shikijs/transformers": "^3.12.2",
+		"@shikijs/themes": "^3.12.2",
 		"@testing-library/dom": "^10.4.1",
 		"@testing-library/jest-dom": "^6.8.0",
 		"@testing-library/preact": "^3.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,9 @@ importers:
       '@shikijs/rehype':
         specifier: ^3.12.2
         version: 3.12.2
+      '@shikijs/themes':
+        specifier: ^3.12.2
+        version: 3.12.2
       '@shikijs/transformers':
         specifier: ^3.12.2
         version: 3.12.2

--- a/src/constants/env/env-astro.ts
+++ b/src/constants/env/env-astro.ts
@@ -8,7 +8,8 @@ export default {
 	SITE_URL: import.meta.env.DEV
 		? "http://localhost:4321"
 		: import.meta.env.SITE,
-	VERCEL_GIT_COMMIT_REF: import.meta.env.VERCEL_GIT_COMMIT_REF,
+	GIT_COMMIT_REF:
+		import.meta.env.GIT_COMMIT_REF ?? import.meta.env.VERCEL_GIT_COMMIT_REF,
 	ORAMA_PRIVATE_API_KEY: import.meta.env.ORAMA_PRIVATE_API_KEY,
 	GITHUB_TOKEN: import.meta.env.GITHUB_TOKEN,
 	HOOF_URL: import.meta.env.HOOF_URL ?? "https://hoof.playfulprogramming.com",

--- a/src/constants/env/env-node.ts
+++ b/src/constants/env/env-node.ts
@@ -6,7 +6,8 @@ export default {
 	PROD: process.env.MODE == "production",
 	DEV: process.env.MODE != "production",
 	SITE_URL: process.env.SITE_URL ?? "https://playfulprogramming.com",
-	VERCEL_GIT_COMMIT_REF: process.env.VERCEL_GIT_COMMIT_REF,
+	GIT_COMMIT_REF:
+		process.env.GIT_COMMIT_REF ?? process.env.VERCEL_GIT_COMMIT_REF,
 	ORAMA_PRIVATE_API_KEY: process.env.ORAMA_PRIVATE_API_KEY,
 	GITHUB_TOKEN: process.env.GITHUB_TOKEN,
 	HOOF_URL: process.env.HOOF_URL ?? "https://hoof.playfulprogramming.com",

--- a/src/constants/env/types.ts
+++ b/src/constants/env/types.ts
@@ -4,7 +4,7 @@ export interface Environment {
 	readonly PROD: boolean;
 	readonly DEV: boolean;
 	readonly SITE_URL: string;
-	readonly VERCEL_GIT_COMMIT_REF: string | undefined;
+	readonly GIT_COMMIT_REF: string | undefined;
 	readonly ORAMA_PRIVATE_API_KEY: string | undefined;
 	readonly GITHUB_TOKEN: string | undefined;
 	readonly HOOF_URL: string;

--- a/src/utils/markdown/components/code-embed/getStackblitzUrl.ts
+++ b/src/utils/markdown/components/code-embed/getStackblitzUrl.ts
@@ -1,3 +1,4 @@
+import env from "constants/env";
 import { siteMetadata } from "constants/site-config";
 import GitBranch from "git-branch";
 
@@ -6,7 +7,7 @@ type StackblitzOpts = {
 	file?: string;
 };
 
-const currentBranch = process.env.VERCEL_GIT_COMMIT_REF ?? (await GitBranch());
+const currentBranch = env.GIT_COMMIT_REF ?? (await GitBranch());
 
 export function getStackblitzUrl(projectDir: string, opts: StackblitzOpts) {
 	if (projectDir.startsWith("/")) {


### PR DESCRIPTION
This contains changes for the migration to fly.io:
- The site is hosted statically with nginx rules
- Initially, this is deployed from main (through the fly.yml workflow) with `ENABLE_DISCOVERABILITY=false`
- This can be previewed on https://playful-web.fly.dev/

TODO:
- [ ] Copy the rewrites from vercel.json into the nginx config
- [ ] Document docker testing/deployment

Out of scope / will be future PRs:
- Creating on-demand PR review builds