### PR TITLE
Modify details summary in CSS specificity post

### DIFF
--- a/content/ckhackshaw/posts/css-specificity-explained/index.md
+++ b/content/ckhackshaw/posts/css-specificity-explained/index.md
@@ -209,7 +209,7 @@ To recap, when calculating specificity, each selector adds to one of three colum
   }
 </style>
 ```
-<details><summary>View answer</summary>0-2-1</details>
+<details><summary>View answer</summary>0-3-0</details>
 
 ```html
 <style>


### PR DESCRIPTION
Hey there,

I believe the specificity of this example is wrong. Earlier in the post you use `.class.class.class` as `0-3-0`, so this should be the same.

I also tested this against the https://specificity.keegan.st/

<img width="815" height="269" alt="image" src="https://github.com/user-attachments/assets/721bd61b-7be5-4bc7-9bed-faf0946a5428" />
