### PR TITLE
fix: dark mode toggle is now smooth again

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -20,7 +20,7 @@
 :root {
 	scrollbar-gutter: stable;
 	scrollbar-color: var(--focus-outline_primary) transparent;
-	transition: scrollbar-color $animStyle $animSpeed;
+	transition: scrollbar-color var(--animation_style) var(--animation_style);
 
 	box-sizing: border-box;
 }
@@ -76,8 +76,8 @@ body {
 	padding: 0;
 	color: var(--foreground_emphasis-high);
 	transition:
-		color $animStyle $animSpeed,
-		background-color $animStyle $animSpeed;
+		color var(--animation_style) var(--animation_speed),
+		background-color var(--animation_style) var(--animation_speed);
 }
 
 .medium-zoom-overlay,

--- a/src/tokens/_utils.scss
+++ b/src/tokens/_utils.scss
@@ -10,7 +10,7 @@
 	@each $prop in $properties {
 		$transitions: list.append(
 			$transitions,
-			$prop vars.$animStyle vars.$animSpeed,
+			$prop var(--animation_style) var(--animation_speed),
 			comma
 		);
 	}

--- a/src/tokens/_vars.scss
+++ b/src/tokens/_vars.scss
@@ -1,2 +1,4 @@
-$animSpeed: 200ms;
-$animStyle: ease-in-out;
+:root {
+	--animation_speed: 200ms;
+	--animation_style: ease-in-out;
+}

--- a/src/views/base/navigation/header.module.scss
+++ b/src/views/base/navigation/header.module.scss
@@ -27,11 +27,11 @@ header {
 	&[data-sticky="pinned"] {
 		border-bottom: 1px solid var(--background_disabled);
 	}
-	background-color: var(--background_primary);
-	top: 0px;
+	top: 0;
 	position: sticky;
 	z-index: 3;
 	transition: border-bottom 0.5s ease;
+	@include transition(background-color);
 
 	@include until($tabletLarge) {
 		&[data-mobile_table_of_contents_present="true"] {


### PR DESCRIPTION
Previously, toggling dark mode would move the header to a different speed than the rest of the page, making it feel jarring. This PR fixes this and moves us to CSS variables for the transition.