### PR TITLE
Improve Cache-Control responses in nginx to avoid cache misses 

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -29,7 +29,7 @@ server {
 	try_files $uri/index.html $uri/ $uri =404;
 	absolute_redirect off;
 
-	add_header Cache-Control "public, max-age=0, must-revalidate";
+	add_header Cache-Control "public, max-age=86400, stale-while-revalidate=604800";
 	add_header Cross-Origin-Embedder-Policy "require-corp";
 	add_header Cross-Origin-Opener-Policy "same-origin";
 
@@ -37,11 +37,11 @@ server {
 
 	# Cache Astro computed assets for 1d
     location /_astro/ {
-        add_header Cache-Control "public, max-age=86400, immutable";
+        add_header Cache-Control "public, max-age=86400, stale-while-revalidate=604800, immutable";
     }
 
     # Cache large or static assets for 1yr
-    location ~* \.(png|jpg|jpeg|gif|mp4|ttf|woff|woff2)$ {
+    location ~* \.(png|jpg|jpeg|gif|svg|avif|mp4|ttf|woff|woff2|pdf)$ {
         add_header Cache-Control "public, max-age=31536000, immutable";
     }
 


### PR DESCRIPTION
Adds a 24h cache + 1 week `stale-while-revalidate` period by default to all requests (this is okay for now while the site remains static)

Treats svg/avif/pdf extensions as static assets.