### PR TITLE
docs: link to internal url from articles

### DIFF
--- a/content/ckhackshaw/posts/how-i-chose-the-tech-stack-for-job-helper/index.md
+++ b/content/ckhackshaw/posts/how-i-chose-the-tech-stack-for-job-helper/index.md
@@ -16,7 +16,7 @@ This has created a situation, where hiring has become very competitive. Staring 
 
 However from the very beginning, I realised that this was not going to be your regular CRUD app. The requirements were a bit more tailored. During the design phase, I asked myslef one important question shaped the entire project: How do I design a stack that balances performance, maintainability, and real-world usefulness?
 
-This article, inspired by Corbin Crutchley's [How to Pick Tech Stacks For New Projects](https://playfulprogramming.com/posts/how-to-pick-tech-stacks-for-new-projects), walks through the functional needs of Job Helper, the technical decisions I made to support them, and my thought process when making these decisions. (why I believe they were the right tradeoffs.)
+This article, inspired by Corbin Crutchley's [How to Pick Tech Stacks For New Projects](/posts/how-to-pick-tech-stacks-for-new-projects), walks through the functional needs of Job Helper, the technical decisions I made to support them, and my thought process when making these decisions. (why I believe they were the right tradeoffs.)
 
 ![Job Helper Architecture](./job_helper_architecture.png)
 

--- a/content/crutchcorn/collections/art-of-accessibility/posts/art-of-a11y-preface/index.md
+++ b/content/crutchcorn/collections/art-of-accessibility/posts/art-of-a11y-preface/index.md
@@ -37,7 +37,7 @@ Now, take this button:
 
 <button aria-label="A large button with dark blue border, dark green 'buy now' text, and light red text" style="background: #ffabab; border: 2rem solid #082450; color: #213224; font-size: 4rem;" > Buy Now </button>
 
-This button works, and [has good contrast](https://playfulprogramming.com/posts/intro-to-web-accessibility#contrast), but might confuse some users whether it's a button or not.
+This button works, and [has good contrast](/posts/intro-to-web-accessibility#contrast), but might confuse some users whether it's a button or not.
 
 Compare this button, with harsh edges and three different colors, against a button from Google's Material Design:
 

--- a/content/crutchcorn/collections/art-of-accessibility/posts/art-of-a11y-text/index.md
+++ b/content/crutchcorn/collections/art-of-accessibility/posts/art-of-a11y-text/index.md
@@ -175,7 +175,7 @@ Yes, my dear reader; with very few exceptions your font sizes should not be base
 
 Here, we're using `rem` to tell our `<p>` element that "regardless of the size of the parent elements, size it 1.25 times the user's default font size" and that the `<code>` element should be "0.9 times the size of the `<p>` element's `font-size`".
 
-> While [we have a guide that explains `em` and `rem` in more depth](https://playfulprogramming.com/posts/web-fundamentals-css), the gist of it is that `em` should be used when you want to position an element's `font-size` relative to its parent, while `rem` should be used for any absolute value of `font-size`.
+> While [we have a guide that explains `em` and `rem` in more depth](/posts/web-fundamentals-css), the gist of it is that `em` should be used when you want to position an element's `font-size` relative to its parent, while `rem` should be used for any absolute value of `font-size`.
 
 
 

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals-v1-1/posts/ffg-fundamentals-v1-1-error-handling/index.md
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals-v1-1/posts/ffg-fundamentals-v1-1-error-handling/index.md
@@ -777,7 +777,7 @@ Unfortunately, React is not able to handle thrown errors invisibly to the user w
 
 ## Angular
 
-As covered before, Angular is able to ignore all errors thrown outside the `constructor` method. However, if an error does occur in the `constructor` method, it's challenging ([but not impossible](https://playfulprogramming.com/posts/angular-constructor-error-behavior#The-short-term-fix)) to sidestep. Because of the complexity of the code required to ignore `constructor` method errors, we won't cover it in this book.
+As covered before, Angular is able to ignore all errors thrown outside the `constructor` method. However, if an error does occur in the `constructor` method, it's challenging ([but not impossible](/posts/angular-constructor-error-behavior#The-short-term-fix)) to sidestep. Because of the complexity of the code required to ignore `constructor` method errors, we won't cover it in this book.
 
 ## Vue
 

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals-v1/posts/ffg-fundamentals-v1-error-handling/index.md
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals-v1/posts/ffg-fundamentals-v1-error-handling/index.md
@@ -776,7 +776,7 @@ Unfortunately, React is not able to handle thrown errors invisibly to the user w
 
 ## Angular
 
-As covered before, Angular is able to ignore all errors thrown outside the `constructor` method. However, if an error does occur in the `constructor` method, it's challenging ([but not impossible](https://playfulprogramming.com/posts/angular-constructor-error-behavior#The-short-term-fix)) to sidestep. Because of the complexity of the code required to ignore `constructor` method errors, we won't cover it in this book.
+As covered before, Angular is able to ignore all errors thrown outside the `constructor` method. However, if an error does occur in the `constructor` method, it's challenging ([but not impossible](/posts/angular-constructor-error-behavior#The-short-term-fix)) to sidestep. Because of the complexity of the code required to ignore `constructor` method errors, we won't cover it in this book.
 
 > Want to see an official solution to this problem? [Star my feature request on GitHub, which outlines a longer-term solution built-into Angular](https://github.com/angular/angular/issues/51941).
 

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/index.md
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/index.md
@@ -783,7 +783,7 @@ Unfortunately, React is not able to handle thrown errors invisibly to the user w
 
 ## Angular
 
-As covered before, Angular is able to ignore all errors thrown outside the `constructor` method. However, if an error does occur in the `constructor` method, it's challenging ([but not impossible](https://playfulprogramming.com/posts/angular-constructor-error-behavior#The-short-term-fix)) to sidestep. Because of the complexity of the code required to ignore `constructor` method errors, we won't cover it in this book.
+As covered before, Angular is able to ignore all errors thrown outside the `constructor` method. However, if an error does occur in the `constructor` method, it's challenging ([but not impossible](/posts/angular-constructor-error-behavior#The-short-term-fix)) to sidestep. Because of the complexity of the code required to ignore `constructor` method errors, we won't cover it in this book.
 
 ## Vue
 

--- a/content/crutchcorn/posts/angular-why-no-template-casting/index.md
+++ b/content/crutchcorn/posts/angular-why-no-template-casting/index.md
@@ -84,7 +84,7 @@ The compiler isn't the only trick Angular has up its sleeve to get things workin
 
 Here, a `View Container` represents any place where elements can be dynamically added or removed.
 
-> [You can learn more about Views, View Containers, and templates in this article I wrote a while back](https://playfulprogramming.com/posts/angular-templates-start-to-source).
+> [You can learn more about Views, View Containers, and templates in this article I wrote a while back](/posts/angular-templates-start-to-source).
 
 These View Containers are often represented in the DOM by using an anchor node (typically a [`Comment` node](https://developer.mozilla.org/en-US/docs/Web/API/Comment)) and help facilitate Angular's instruction set to manipulate surrounding elements.
 
@@ -111,7 +111,7 @@ In order for there to be some kind of `as` casting API akin to an imaginary API 
 
 While Angular doesn't have a one-to-one API with React and Vue's `as` type cast, it does have the ability to attach component behavior onto different elements.
 
-Because [Angular uses host elements instead of transparent elements](https://playfulprogramming.com/posts/angular-templates-dont-work-how-you-think), we can tell Angular's selector to use an attribute to lookup rather than a new HTML tag:
+Because [Angular uses host elements instead of transparent elements](/posts/angular-templates-dont-work-how-you-think), we can tell Angular's selector to use an attribute to lookup rather than a new HTML tag:
 
 ```angular-ts
 @Component({

--- a/content/crutchcorn/posts/layered-react-structure/index.md
+++ b/content/crutchcorn/posts/layered-react-structure/index.md
@@ -223,7 +223,7 @@ While many versions of the "Smart" vs "Dumb" component arguments have different 
 
 ## Defining Utilities vs Services {#utils-vs-services}
 
-In 2015 Promises were introduced into JavaScript. While they were a good solution to the problem of [the Christmas tree callback problem](https://playfulprogramming.com/posts/async-and-promises#Callbacks), they weren't intuitive to use until `async` and `await` were implemented in the ecosystem around 2017.
+In 2015 Promises were introduced into JavaScript. While they were a good solution to the problem of [the Christmas tree callback problem](/posts/async-and-promises#Callbacks), they weren't intuitive to use until `async` and `await` were implemented in the ecosystem around 2017.
 
 ```javascript
 function main() {
@@ -503,7 +503,7 @@ describe("PeopleView", () => {
 
 This setup enables you to validate actual user behavior rather than testing implementation details.
 
-> Want to learn more about best testing practices? [See our article for 5 suggestions to write the best tests you can.](https://playfulprogramming.com/posts/five-suggestions-for-simpler-tests)
+> Want to learn more about best testing practices? [See our article for 5 suggestions to write the best tests you can.](/posts/five-suggestions-for-simpler-tests)
 
 ## Test Runner {#vitest}
 

--- a/content/crutchcorn/posts/modern-js-bundleless/index.md
+++ b/content/crutchcorn/posts/modern-js-bundleless/index.md
@@ -316,7 +316,7 @@ Now, we'll update our  `package.json` to include the deps we want to use:
 }
 ```
 
-> As a helpful tip, [we can use `devDependencies` to track the tools we don't need to ship to the browser and `dependencies` as the libraries we need in production](https://playfulprogramming.com/posts/how-to-use-npm#dev-deps).
+> As a helpful tip, [we can use `devDependencies` to track the tools we don't need to ship to the browser and `dependencies` as the libraries we need in production](/posts/how-to-use-npm#dev-deps).
 
 And install them using `pnpm`:
 

--- a/content/crutchcorn/posts/monads-explained-in-js/index.md
+++ b/content/crutchcorn/posts/monads-explained-in-js/index.md
@@ -30,7 +30,7 @@ If I may, allow me to try my hand at this.
 > I generally assume that you're familiar with JavaScript and Promises. If you're not, I might suggest the following resources:
 >
 > - [Our "Web Fundamentals" series introducing HTML, CSS, and JavaScript](https://playfulprogramming.com/collections/web-fundamentals).
-> - [My article on `async`, `await`, and Promises in general](https://playfulprogramming.com/posts/async-and-promises).
+> - [My article on `async`, `await`, and Promises in general](/posts/async-and-promises).
 
 # Introducing Monads in JavaScript
 
@@ -113,7 +113,7 @@ This means that the immutable operation of chaining is the `.then`, since each n
 
 > **Another ecosystem's example:**
 >
-> [In Rust, they have the `Option` API](https://playfulprogramming.com/posts/rust-enums-matching-options-api). This API also describes a monad, since it wraps data and adds an "existance" context.
+> [In Rust, they have the `Option` API](/posts/rust-enums-matching-options-api). This API also describes a monad, since it wraps data and adds an "existance" context.
 >
 > It's either `Some` or `None`:
 >
@@ -124,7 +124,7 @@ This means that the immutable operation of chaining is the `.then`, since each n
 > }
 > ```
 >
-> Which can be [chained together](https://playfulprogramming.com/posts/rust-enums-matching-options-api) and implements other monad laws.
+> Which can be [chained together](/posts/rust-enums-matching-options-api) and implements other monad laws.
 
 ----
 

--- a/content/crutchcorn/posts/nextjs-promise-race/index.md
+++ b/content/crutchcorn/posts/nextjs-promise-race/index.md
@@ -57,7 +57,7 @@ export default async function Page() {
 
 This is so cool to me. Notice we didn't need any `"use client"` API usage; these are all server components! But despite that, we're still using the previously client-only `<Suspense>` component to handle data loading!
 
-Not only do React's client and server APIs marry in this code sample, but even the ideas behind JSX-over-the-wire are on full display here: We're _[serializing](https://playfulprogramming.com/posts/intro-to-web-components-vanilla-js#Serializability) a promise to send over the wire_. **Conditionally**.
+Not only do React's client and server APIs marry in this code sample, but even the ideas behind JSX-over-the-wire are on full display here: We're _[serializing](/posts/intro-to-web-components-vanilla-js#Serializability) a promise to send over the wire_. **Conditionally**.
 
 This means that if the promise resolves in time, it will never ship the loading `<div>` to the client!
 

--- a/content/crutchcorn/posts/react-history-through-code/index.md
+++ b/content/crutchcorn/posts/react-history-through-code/index.md
@@ -827,7 +827,7 @@ This doesn't mean that authoring your own custom hooks is a free-for-all, howeve
 - [Dynamic usage of hooks is not allowed](https://react.dev/reference/rules/react-calls-components-and-hooks#dont-dynamically-use-hooks)
 - [Properties passed to hooks must not be mutated](https://react.dev/reference/rules/components-and-hooks-must-be-pure#return-values-and-arguments-to-hooks-are-immutable)
 
-Regardless of if a hook is custom or imported from React, regardless of when a hook was introduced, whether from the start with `useState` or much later with [the `useActionState` hook](https://playfulprogramming.com/posts/what-is-use-action-state-and-form-status), these rules are to be followed.
+Regardless of if a hook is custom or imported from React, regardless of when a hook was introduced, whether from the start with `useState` or much later with [the `useActionState` hook](/posts/what-is-use-action-state-and-form-status), these rules are to be followed.
 
 ```jsx
 // ✅ Allowed usages

--- a/content/crutchcorn/posts/why-is-css-in-js-slow/index.md
+++ b/content/crutchcorn/posts/why-is-css-in-js-slow/index.md
@@ -246,7 +246,7 @@ To the original problem space like this:
 >
 > Earlier I mentioned a list of CSS-in-JS libraries that were slow and ones that compiled to CSS. While this is _generally_ true, it's not always so black and white.
 >
-> After all, some libraries have plugins or [SSR](https://playfulprogramming.com/posts/what-is-ssr-and-ssg) compatibility to either reduce or solve the problems with CSS-in-JS as outlined.
+> After all, some libraries have plugins or [SSR](/posts/what-is-ssr-and-ssg) compatibility to either reduce or solve the problems with CSS-in-JS as outlined.
 
 # Conclusion
 


### PR DESCRIPTION
This moves from `playfulprogramming.com` in links to relative paths