### PR TITLE
Expand revision click area to take the whole available space

### DIFF
--- a/src/components/select/select.module.scss
+++ b/src/components/select/select.module.scss
@@ -43,7 +43,6 @@
 	display: flex;
 	gap: var(--popup_item_gap);
 	align-items: center;
-	padding: var(--popup_item_padding);
 	min-height: var(--popup_item_min-height);
 	border-radius: var(--popup_item_corner-radius);
 	min-width: var(--popup_min-width);
@@ -59,6 +58,10 @@
 
 .option.selected {
 	background-color: var(--popup_item_background-color_selected);
+}
+
+.option.padded {
+	padding: var(--popup_item_padding);
 }
 
 .option:hover {

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -265,7 +265,7 @@ export function Option({ item, state }: OptionProps) {
 		<li
 			{...optionProps}
 			ref={ref}
-			class={`${styles.option} ${isSelected ? styles.selected : ""}`}
+			class={`${styles.option} ${styles.padded} ${isSelected ? styles.selected : ""}`}
 			data-focus-visible={isFocusVisible}
 		>
 			<span className={`text-style-button-regular ${styles.optionText}`}>

--- a/src/views/blog-post/article-revisions/article-revisions.module.scss
+++ b/src/views/blog-post/article-revisions/article-revisions.module.scss
@@ -102,10 +102,12 @@
 	}
 
 	.item {
+		align-self: stretch;
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
 		width: 100%;
+		padding: var(--popup_item_padding);
 		text-decoration: none;
 		min-width: var(--popup_min-width);
 


### PR DESCRIPTION
Fixes: #1519

As the issue stated, the revision click area doesn't take the whole space of the option. After some research on the codebase, I found that the `.option` class only used in two places:  [`basic-option.tsx`](https://github.com/playfulprogramming/playfulprogramming/blob/main/src/components/select/basic-option.tsx) and [`select.tsx`](https://github.com/playfulprogramming/playfulprogramming/blob/main/src/components/select/select.tsx).

The `basic-option.tsx` is for rendering a arbitrary element under the options. It is used under the hood in [`article-revisions.tsx`](https://github.com/playfulprogramming/playfulprogramming/blob/main/src/views/blog-post/article-revisions/article-revisions.tsx) and not used anywhere else.

So I updated the `select.tsx` to use another class (`.option.padded`) for padding and remove the padding from the `.option` class. And added a padding manually to the revision item and also make it full height because there was a very small not clickable area because of the `min-height` property in `.option`. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined select component option padding behavior to be more flexible and conditional
  * Enhanced spacing and alignment presentation in article revision popup items

<!-- end of auto-generated comment: release notes by coderabbit.ai -->