### PR TITLE
Fix code embed / details styling issues

### DIFF
--- a/src/components/code-embed/code-embed.tsx
+++ b/src/components/code-embed/code-embed.tsx
@@ -24,7 +24,7 @@ interface ContainerProps {
 
 export function Container(props: ContainerProps) {
 	return (
-		<div class={style.container}>
+		<div class={`${style.container} markdownCollapsePadding`}>
 			<div class={style.title}>
 				<p class="text-style-body-medium-bold">{props.title}</p>
 				{props.editUrl ? (

--- a/src/components/hint/hint.module.scss
+++ b/src/components/hint/hint.module.scss
@@ -65,7 +65,7 @@
 	// The <details> should expand to width: 100% if it contains a full-width
 	// element, such as an iframe or codeblock, as this does not happen
 	// automatically.
-	&[open]:has(:global(pre, .markdownCollapsePadding)) {
+	&[open]:has(pre, :global(.markdownCollapsePadding)) {
 		width: 100%;
 	}
 
@@ -77,15 +77,15 @@
 		transform: rotateZ(180deg);
 	}
 
-	&:hover {
-		background-color: var(--hint-container_background-color_hovered);
-	}
-
-	&:active {
-		background-color: var(--hint-container_background-color_pressed);
-	}
-
 	@supports selector(:has(*)) {
+		&:has(.title:hover) {
+			background-color: var(--hint-container_background-color_hovered);
+		}
+
+		&:has(.title:active) {
+			background-color: var(--hint-container_background-color_pressed);
+		}
+
 		&:has(.title:focus-visible) {
 			background-color: var(--hint-container_background-color_focused);
 			outline: var(--hint_focus-outline_width) solid
@@ -97,6 +97,14 @@
 	// to get the focus state on the parent
 	// - this will incorrectly show the focus state during/after click events even if focus indication is not necessary
 	@supports not selector(:has(*)) {
+		&:hover {
+			background-color: var(--hint-container_background-color_hovered);
+		}
+
+		&:active {
+			background-color: var(--hint-container_background-color_pressed);
+		}
+
 		&:focus-within {
 			background-color: var(--hint-container_background-color_focused);
 			outline: var(--hint_focus-outline_width) solid


### PR DESCRIPTION
Fixes the `width: 100%` not applying correctly to `<details>` tags when a `.markdownCollapsePadding` element is placed inside.

Adds `.markdownCollapsePadding` to the code embed components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced visual styling for code displays and hint components with improved consistency
  * Expanded browser compatibility for advanced styling features
  * Optimized rendering of interactive elements across different browser environments
  * Refined appearance and behavior of collapsible content sections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->