### PR TITLE
Add run_id concurrency group fallback

### DIFF
--- a/.github/workflows/fly-review.yml
+++ b/.github/workflows/fly-review.yml
@@ -18,7 +18,7 @@ env:
     }
 
 concurrency:
-  group: pr-${{ github.event.pull_request.number }}-deploy
+  group: pr-${{ github.event.pull_request.number || github.run_id }}-deploy
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
This prevents PRs from getting kicked out of the merge group if another PR check is queued under the same concurrency group.