### PR TITLE
fix: update even to correct date

### DIFF
--- a/src/views/events/constants.ts
+++ b/src/views/events/constants.ts
@@ -196,11 +196,11 @@ export const bookClubBlocks = [
 		timezone: "America/Los_Angeles",
 	},
 	{
-		slug: "book-club-03-03-2026",
-		starts_at: dayjs("03-03-2026 04:30 PM", "MM-DD-YYYY hh:mm A")
+		slug: "book-club-03-04-2026",
+		starts_at: dayjs("03-04-2026 04:30 PM", "MM-DD-YYYY hh:mm A")
 			.tz("America/Los_Angeles", true)
 			.toDate(),
-		ends_at: dayjs("03-03-2026 05:30 PM", "MM-DD-YYYY hh:mm A")
+		ends_at: dayjs("03-04-2026 05:30 PM", "MM-DD-YYYY hh:mm A")
 			.tz("America/Los_Angeles", true)
 			.toDate(),
 		location_description: 'The "You" in CPU: Fork-Exec',


### PR DESCRIPTION
bump event date to next (correct) day. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Book Club event rescheduled from March 3, 2026 to March 4, 2026 at 4:30 PM.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->