### PR TITLE
Add minimum release age configuration to pnpm-workspace.yaml

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
 packages:
   - "e2e"
   - "."
+
+minimumReleaseAge: 10080 # 7 days


### PR DESCRIPTION
Fixes: #1605

Unlike from the suggested day in the issue, the `minimumReleaseAge` configured as `7 days` to cover more incidents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release configuration to enforce a minimum time interval between releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->