### PR TITLE
PNPM 11 and CI upgrades

### DIFF
--- a/.github/workflows/fly-review.yml
+++ b/.github/workflows/fly-review.yml
@@ -113,7 +113,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: superfly/flyctl-actions/setup-flyctl@fc53c09e1bc3be6f54706524e3b82c4f462f77be # v1.5
+      - uses: superfly/flyctl-actions/setup-flyctl@fc53c09e1bc3be6f54706524e3b82c4f462f77be # 1.5
 
       - id: status
         name: Retrieve app status

--- a/.github/workflows/fly-review.yml
+++ b/.github/workflows/fly-review.yml
@@ -104,6 +104,8 @@ jobs:
     steps:
       # This checks out the main branch! So everything in this job can be trusted (except for the image being deployed)
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: superfly/flyctl-actions/setup-flyctl@fc53c09e1bc3be6f54706524e3b82c4f462f77be #v1.5
 

--- a/.github/workflows/fly-review.yml
+++ b/.github/workflows/fly-review.yml
@@ -4,6 +4,7 @@ on:
   # Note: this pull_request_target usage is quite unsafe!
   # Be very careful about making changes to this file!
   # It has been the cause of multiple GHA-related exploits!
+  # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     types: [opened, reopened, synchronize, closed]
   merge_group:

--- a/.github/workflows/fly-review.yml
+++ b/.github/workflows/fly-review.yml
@@ -33,7 +33,7 @@ jobs:
       pull-requests: read
     steps:
       - id: changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.1.0
         with:
           filters: |
             unsafe:
@@ -58,16 +58,16 @@ jobs:
       packages: write
     steps:
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: https://ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # This checks out the PR merge contents, which COULD CONTAIN UNSAFE CODE!
           # It is very important that no secrets are provided to the docker build!
@@ -75,7 +75,7 @@ jobs:
           persist-credentials: false
 
       - name: Build Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           push: ${{ github.event_name == 'pull_request_target' }}
@@ -103,9 +103,9 @@ jobs:
 
     steps:
       # This checks out the main branch! So everything in this job can be trusted (except for the image being deployed)
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: superfly/flyctl-actions/setup-flyctl@1.5
+      - uses: superfly/flyctl-actions/setup-flyctl@fc53c09e1bc3be6f54706524e3b82c4f462f77be #v1.5
 
       - id: status
         name: Retrieve app status

--- a/.github/workflows/fly-review.yml
+++ b/.github/workflows/fly-review.yml
@@ -36,7 +36,7 @@ jobs:
       pull-requests: read
     steps:
       - id: changes
-        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.1.0
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
           filters: |
             unsafe:
@@ -113,7 +113,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: superfly/flyctl-actions/setup-flyctl@fc53c09e1bc3be6f54706524e3b82c4f462f77be #v1.5
+      - uses: superfly/flyctl-actions/setup-flyctl@fc53c09e1bc3be6f54706524e3b82c4f462f77be # v1.5
 
       - id: status
         name: Retrieve app status

--- a/.github/workflows/fly-review.yml
+++ b/.github/workflows/fly-review.yml
@@ -22,6 +22,8 @@ concurrency:
   group: pr-${{ github.event.pull_request.number || github.run_id }}-deploy
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   # If the PR is from a fork, and changes anything outside of the content folder, it needs to be manually reviewed
   check-pr:
@@ -46,6 +48,7 @@ jobs:
     if: ${{ needs.check-pr.outputs.unsafe != 'false' }}
     runs-on: ubuntu-latest
     environment: review-unsafe
+    permissions: {}
     steps:
       - name: Wait for approval
         run: echo 'Approved to build and deploy'
@@ -93,6 +96,8 @@ jobs:
     if: ${{ !cancelled() && github.event_name == 'pull_request_target' && needs.build.result != 'failure' }}
     needs: [build]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       url: ${{ steps.deploy.outputs.url }}
     environment:

--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -76,6 +76,6 @@ jobs:
           VARS_FASTLY_SERVICE_ID: ${{ vars.FASTLY_SERVICE_ID }}
         run: |
           # https://www.fastly.com/documentation/guides/full-site-delivery/purging/working-with-surrogate-keys/
-          curl -i -X POST 'https://api.fastly.com/service/${VARS_FASTLY_SERVICE_ID}/purge/purge-on-deploy' \
+          curl -i -X POST "https://api.fastly.com/service/${VARS_FASTLY_SERVICE_ID}/purge/purge-on-deploy" \
             -H "Fastly-Key: $FASTLY_API_KEY" \
             -H 'fastly-soft-purge: 1'

--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: superfly/flyctl-actions/setup-flyctl@fc53c09e1bc3be6f54706524e3b82c4f462f77be #v1.5
+      - uses: superfly/flyctl-actions/setup-flyctl@fc53c09e1bc3be6f54706524e3b82c4f462f77be # v1.5
       - name: Deploy app
         run: |
           flyctl deploy --image "$DOCKER_TAG"

--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -23,7 +23,7 @@ jobs:
           persist-credentials: false
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: https://ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -19,6 +19,8 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -58,6 +60,8 @@ jobs:
       FLY_API_TOKEN: ${{ secrets.FLY_WEB_DEPLOY_TOKEN }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: superfly/flyctl-actions/setup-flyctl@fc53c09e1bc3be6f54706524e3b82c4f462f77be #v1.5
       - name: Deploy app
         run: |
@@ -65,8 +69,9 @@ jobs:
       - name: Purge Fastly cache
         env:
           FASTLY_API_KEY: ${{ secrets.FASTLY_API_KEY }}
+          VARS_FASTLY_SERVICE_ID: ${{ vars.FASTLY_SERVICE_ID }}
         run: |
           # https://www.fastly.com/documentation/guides/full-site-delivery/purging/working-with-surrogate-keys/
-          curl -i -X POST 'https://api.fastly.com/service/${{ vars.FASTLY_SERVICE_ID }}/purge/purge-on-deploy' \
+          curl -i -X POST 'https://api.fastly.com/service/${VARS_FASTLY_SERVICE_ID}/purge/purge-on-deploy' \
             -H "Fastly-Key: $FASTLY_API_KEY" \
             -H 'fastly-soft-purge: 1'

--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       packages: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -28,10 +28,10 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Build Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           push: true
@@ -57,8 +57,8 @@ jobs:
     env:
       FLY_API_TOKEN: ${{ secrets.FLY_WEB_DEPLOY_TOKEN }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: superfly/flyctl-actions/setup-flyctl@1.5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: superfly/flyctl-actions/setup-flyctl@fc53c09e1bc3be6f54706524e3b82c4f462f77be #v1.5
       - name: Deploy app
         run: |
           flyctl deploy --image "$DOCKER_TAG"

--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: superfly/flyctl-actions/setup-flyctl@fc53c09e1bc3be6f54706524e3b82c4f462f77be # v1.5
+      - uses: superfly/flyctl-actions/setup-flyctl@fc53c09e1bc3be6f54706524e3b82c4f462f77be # 1.5
       - name: Deploy app
         run: |
           flyctl deploy --image "$DOCKER_TAG"

--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -11,6 +11,8 @@ concurrency:
   group: main-deploy
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   build:
     name: Build image
@@ -53,6 +55,8 @@ jobs:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     needs: [build]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     environment:
       name: production
       url: https://playfulprogramming.com

--- a/.github/workflows/search-index.yml
+++ b/.github/workflows/search-index.yml
@@ -12,13 +12,13 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: ".nvmrc"
           cache: "pnpm"

--- a/.github/workflows/search-index.yml
+++ b/.github/workflows/search-index.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8

--- a/.github/workflows/search-index.yml
+++ b/.github/workflows/search-index.yml
@@ -8,6 +8,9 @@ on:
 env:
   CI: true
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,13 +21,13 @@ jobs:
       CI: true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -41,14 +41,14 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           lfs: true
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -60,7 +60,7 @@ jobs:
           echo "GID=$(id -g)" >> $GITHUB_ENV
       - name: Run Playwright tests (Docker)
         run: pnpm --filter e2e test
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() }}
         with:
           name: playwright-report
@@ -73,13 +73,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -95,13 +95,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .nvmrc
           cache: pnpm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - name: Setup Node
@@ -45,6 +46,7 @@ jobs:
         with:
           fetch-depth: 0
           lfs: true
+          persist-credentials: false
       - name: Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - name: Setup Node
@@ -76,6 +78,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - name: Setup Node
@@ -98,6 +101,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - name: Setup Node

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test-unit:
     env:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,25 @@
+name: GitHub Actions Security Analysis
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          advanced-security: false
+          annotations: true

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-# Expose Astro dependencies for `pnpm` users
-shamefully-hoist=true

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"type": "git",
 		"url": "git+https://github.com/playfulprogramming/playfulprogramming.git"
 	},
-	"packageManager": "pnpm@10.28.1",
+	"packageManager": "pnpm@11.4.0+sha512.f0febc7e37552ab485494a914241b338e0b3580b93d54ce31f00933015880863129038a1b4ae4e414a0ee63ac35bf21197e990172c4a68256450b5636310968f",
 	"engines": {
 		"node": "24.x"
 	},
@@ -175,12 +175,6 @@
 		"react-stately": "^3.43.0",
 		"typesense": "^2.1.0",
 		"uuid": "^13.0.0"
-	},
-	"pnpm": {
-		"overrides": {
-			"react": "npm:@preact/compat@18.3.1",
-			"react-dom": "npm:@preact/compat@18.3.1"
-		}
 	},
 	"msw": {
 		"workerDirectory": [

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,13 @@
+shamefullyHoist: true
 packages:
-  - "e2e"
-  - "."
-
-minimumReleaseAge: 10080 # 7 days
+  - e2e
+  - .
+minimumReleaseAge: 10080
+overrides:
+  react: 'npm:@preact/compat@18.3.1'
+  react-dom: 'npm:@preact/compat@18.3.1'
+allowBuilds:
+  '@parcel/watcher': true
+  esbuild: true
+  msw: true
+  sharp: true


### PR DESCRIPTION
- Upgrades PNPM to 11
- Introduces Zizmor for CI linting
- Locks GH actions to commits
- Upgrades all GH actions
- Reduces perms for various CI actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package manager to pnpm 11.4.0.
  * Pinned GitHub Actions to specific commits for more deterministic and secure CI runs.
  * Added a GitHub Actions security analysis workflow.
  * Adjusted dependency hoisting and override settings in workspace configuration.
  * Removed legacy hoisting setting from npm config.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/playfulprogramming/playfulprogramming/pull/1609?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->