### PR TITLE
Fix codebase running in Git Worktree

### DIFF
--- a/src/utils/markdown/components/code-embed/getStackblitzUrl.ts
+++ b/src/utils/markdown/components/code-embed/getStackblitzUrl.ts
@@ -7,7 +7,19 @@ type StackblitzOpts = {
 	file?: string;
 };
 
-const currentBranch = env.GIT_COMMIT_REF ?? (await GitBranch());
+let currentBranch: string | undefined;
+
+try {
+	currentBranch = env.GIT_COMMIT_REF ?? (await GitBranch());
+} catch (error) {
+	// In a worktree, this will fail, so we default to "main" to avoid breaking the embed functionality.
+	console.error("Error getting current Git branch:", error);
+	currentBranch = "main";
+	// But only for development, in production we should throw an error to avoid unexpected behavior.
+	if (env.MODE === "production") {
+		throw error;
+	}
+}
 
 export function getStackblitzUrl(projectDir: string, opts: StackblitzOpts) {
 	if (projectDir.startsWith("/")) {


### PR DESCRIPTION
I noticed the PFP site wouldn't run in a Git Worktree. This PR fixes that

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when generating StackBlitz links by falling back to the main branch when branch detection fails outside production.
  - Preserved error reporting in production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->