### PR TITLE
Remove DayJS in favor of Intl

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
 		"astro-icon": "^1.1.5",
 		"autoprefixer": "^10.5.0",
 		"classnames": "^2.3.2",
-		"dayjs": "^1.11.21",
 		"emoji-regex": "^10.6.0",
 		"esbuild": "^0.28.0",
 		"eslint": "^10.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,9 +163,6 @@ importers:
       classnames:
         specifier: ^2.3.2
         version: 2.5.1
-      dayjs:
-        specifier: ^1.11.21
-        version: 1.11.21
       emoji-regex:
         specifier: ^10.6.0
         version: 10.6.0
@@ -2960,9 +2957,6 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
-
-  dayjs@1.11.21:
-    resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -9380,8 +9374,6 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
-
-  dayjs@1.11.21: {}
 
   debug@2.6.9:
     dependencies:

--- a/src/components/x-embed/x-embed.tsx
+++ b/src/components/x-embed/x-embed.tsx
@@ -1,5 +1,3 @@
-import dayjs from "dayjs";
-import advancedFormat from "dayjs/plugin/advancedFormat";
 import { Button, IconOnlyButton } from "#components/button/button.tsx";
 import discussion from "#src/icons/discussion.svg?raw";
 import repost from "#src/icons/repost.svg?raw";
@@ -7,8 +5,7 @@ import heart from "#src/icons/heart.svg?raw";
 import launch from "#src/icons/launch.svg?raw";
 import style from "./x-embed.module.scss";
 import { RawSvg } from "#components/image/raw-svg.tsx";
-
-dayjs.extend(advancedFormat);
+import { formatDate, formatEnglishOrdinalDate, toDate } from "#utils/date.ts";
 
 interface XEmbedPicture {
 	src: string;
@@ -42,7 +39,21 @@ export function XEmbedPlaceholder({
 	link,
 	picture,
 }: XEmbedPlaceholderProps) {
-	const dayjsDate = dayjs(date);
+	const postDate = toDate(date);
+	const isValidDate = !Number.isNaN(postDate.valueOf());
+	const formattedDate = isValidDate
+		? formatEnglishOrdinalDate(postDate, {
+				month: "short",
+				day: "numeric",
+				year: "numeric",
+			})
+		: date;
+	const formattedTime = isValidDate
+		? formatDate(postDate, {
+				hour: "numeric",
+				minute: "2-digit",
+			})
+		: undefined;
 	return (
 		<div className={style.container}>
 			<div className={style.topContainer}>
@@ -122,15 +133,17 @@ export function XEmbedPlaceholder({
 					</div>
 				</div>
 				<p className={style.timeContainer}>
-					<span className={`text-style-body-small-bold`}>
-						{dayjsDate.format("MMM Do, YYYY")}
-					</span>
-					<span className={`text-style-body-small ${style.timeSaparator}`}>
-						•
-					</span>
-					<span className={`text-style-body-small ${style.time}`}>
-						{dayjsDate.format("h:mm A")}
-					</span>
+					<span className={`text-style-body-small-bold`}>{formattedDate}</span>
+					{formattedTime ? (
+						<>
+							<span className={`text-style-body-small ${style.timeSaparator}`}>
+								•
+							</span>
+							<span className={`text-style-body-small ${style.time}`}>
+								{formattedTime}
+							</span>
+						</>
+					) : null}
 				</p>
 			</div>
 		</div>

--- a/src/pages/sitemap-0.xml.ts
+++ b/src/pages/sitemap-0.xml.ts
@@ -5,7 +5,7 @@ import {
 	streamToPromise,
 } from "sitemap";
 import * as api from "#utils/api.ts";
-import dayjs from "dayjs";
+import { toDate } from "#utils/date.ts";
 import type { PostInfo } from "#types/PostInfo.ts";
 import type { CollectionInfo } from "#types/CollectionInfo.ts";
 import type { Languages } from "#types/index.ts";
@@ -21,7 +21,7 @@ const sitemapDefaults: Pick<
 	SitemapItemLoose,
 	"lastmod" | "changefreq" | "priority"
 > = {
-	lastmod: dayjs().toISOString(),
+	lastmod: new Date().toISOString(),
 	changefreq: EnumChangefreq.DAILY,
 	priority: 0.7,
 };
@@ -83,7 +83,7 @@ export const GET = async () => {
 			...sitemapDefaults,
 			url: createPostUrl(post.locale, post),
 			links,
-			lastmod: dayjs(post.edited ?? post.published).toISOString(),
+			lastmod: toDate(post.edited ?? post.published).toISOString(),
 		});
 	}
 

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -15,7 +15,7 @@ import { isNotJunk as baseIsNotJunk } from "junk";
 import { getImageSize } from "../utils/get-image-size.ts";
 import { resolvePath } from "./url-paths.ts";
 import matter from "gray-matter";
-import dayjs from "dayjs";
+import { formatDate } from "./date.ts";
 
 import { unified } from "unified";
 import remarkParse from "remark-parse";
@@ -376,9 +376,18 @@ async function readPost(
 			excerpt,
 			publishedMeta:
 				frontmatter.published &&
-				dayjs(frontmatter.published).format("MMMM D, YYYY"),
+				formatDate(frontmatter.published, {
+					month: "long",
+					day: "numeric",
+					year: "numeric",
+				}),
 			editedMeta:
-				frontmatter.edited && dayjs(frontmatter.edited).format("MMMM D, YYYY"),
+				frontmatter.edited &&
+				formatDate(frontmatter.edited, {
+					month: "long",
+					day: "numeric",
+					year: "numeric",
+				}),
 			coverImgMeta,
 			socialImgMeta,
 		});

--- a/src/utils/date.node.spec.ts
+++ b/src/utils/date.node.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "vitest";
+import {
+	formatCompactTime,
+	formatDate,
+	formatEnglishOrdinalDate,
+	toDate,
+} from "./date.ts";
+
+describe("formatEnglishOrdinalDate", () => {
+	test.each([
+		[1, "Jun 1st, 2023"],
+		[2, "Jun 2nd, 2023"],
+		[3, "Jun 3rd, 2023"],
+		[4, "Jun 4th, 2023"],
+		[11, "Jun 11th, 2023"],
+		[12, "Jun 12th, 2023"],
+		[13, "Jun 13th, 2023"],
+		[21, "Jun 21st, 2023"],
+		[22, "Jun 22nd, 2023"],
+		[23, "Jun 23rd, 2023"],
+	])("formats the %i day", (day, expected) => {
+		expect(
+			formatEnglishOrdinalDate(new Date(2023, 5, day, 12), {
+				month: "short",
+				day: "numeric",
+				year: "numeric",
+			}),
+		).toBe(expected);
+	});
+});
+
+test("interprets ISO date-only strings in the local time zone", () => {
+	const date = toDate("2026-01-18");
+
+	expect([date.getFullYear(), date.getMonth(), date.getDate()]).toEqual([
+		2026, 0, 18,
+	]);
+	expect(
+		formatDate("2026-01-18", {
+			month: "long",
+			day: "numeric",
+			year: "numeric",
+		}),
+	).toBe("January 18, 2026");
+});
+
+test("preserves years below 100 in ISO date-only strings", () => {
+	const date = toDate("0099-01-18");
+
+	expect([date.getFullYear(), date.getMonth(), date.getDate()]).toEqual([
+		99, 0, 18,
+	]);
+});
+
+test("formats compact event times without a day-period separator", () => {
+	expect(formatCompactTime(new Date(2026, 3, 2, 18, 5))).toBe("6:05PM");
+});

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,84 @@
+type DateInput = Date | number | string;
+
+const isoDatePattern = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+const englishOrdinalSuffixes = {
+	zero: "th",
+	one: "st",
+	two: "nd",
+	few: "rd",
+	many: "th",
+	other: "th",
+} as const satisfies Record<Intl.LDMLPluralRule, string>;
+
+const englishOrdinalRules = new Intl.PluralRules("en-US", {
+	type: "ordinal",
+});
+
+/**
+ * Converts a date-like value to a Date. ISO date-only strings are interpreted in
+ * the local time zone, matching the behavior of the date metadata they represent.
+ */
+export function toDate(value: DateInput): Date {
+	if (value instanceof Date || typeof value === "number") {
+		return new Date(value);
+	}
+
+	const isoDate = isoDatePattern.exec(value);
+	if (isoDate) {
+		const [, year, month, day] = isoDate;
+		const date = new Date(0);
+		date.setFullYear(Number(year), Number(month) - 1, Number(day));
+		date.setHours(0, 0, 0, 0);
+		return date;
+	}
+
+	return new Date(value);
+}
+
+export function formatDate(
+	value: DateInput,
+	options: Intl.DateTimeFormatOptions,
+) {
+	return new Intl.DateTimeFormat("en-US", options).format(toDate(value));
+}
+
+/**
+ * Formats an English date and adds the locale's ordinal suffix to its day part.
+ */
+export function formatEnglishOrdinalDate(
+	value: DateInput,
+	options: Intl.DateTimeFormatOptions,
+) {
+	const date = toDate(value);
+	const formatter = new Intl.DateTimeFormat("en-US", options);
+	const parts = formatter.formatToParts(date);
+	const day = parts.find((part) => part.type === "day");
+
+	if (!day) return formatter.format(date);
+
+	const ordinalRule = englishOrdinalRules.select(Number(day.value));
+	return parts
+		.map((part) =>
+			part.type === "day"
+				? `${part.value}${englishOrdinalSuffixes[ordinalRule]}`
+				: part.value,
+		)
+		.join("");
+}
+
+/** Formats the compact English time used by event cards (for example, 2:30PM). */
+export function formatCompactTime(value: DateInput) {
+	const parts = new Intl.DateTimeFormat("en-US", {
+		hour: "numeric",
+		minute: "2-digit",
+	}).formatToParts(toDate(value));
+
+	return parts
+		.filter(
+			(part, index) =>
+				part.type !== "literal" || parts[index + 1]?.type !== "dayPeriod",
+		)
+		.map((part) => part.value)
+		.join("");
+}

--- a/src/views/blog-post/post-title-header/post-title-header.astro
+++ b/src/views/blog-post/post-title-header/post-title-header.astro
@@ -3,7 +3,7 @@ import style from "./post-title-header.module.scss";
 import type { PostInfo, PersonInfo, PostVersion } from "#types/index.ts";
 import { Icon } from "astro-icon/components";
 import { Chip } from "#components/index.ts";
-import dayjs from "dayjs";
+import { formatDate } from "#utils/date.ts";
 import { buildSearchQuery } from "../../search/search.ts";
 import { translate } from "#utils/translations.ts";
 import { ArticleRevisionDropdown } from "../article-revisions/article-revisions.tsx";
@@ -16,8 +16,13 @@ export interface Props {
 const { post, versions, authors } = Astro.props;
 const { title, tags } = post;
 
-const publishedStr = dayjs(post.published).format("MMMM D, YYYY");
-const editedStr = post.edited && dayjs(post.edited).format("MMMM D, YYYY");
+const dateFormat = {
+	month: "long",
+	day: "numeric",
+	year: "numeric",
+} as const satisfies Intl.DateTimeFormatOptions;
+const publishedStr = formatDate(post.published, dateFormat);
+const editedStr = post.edited && formatDate(post.edited, dateFormat);
 
 const originalLinkStr = post.originalLink && new URL(post.originalLink).host;
 ---

--- a/src/views/book-club/book-club.tsx
+++ b/src/views/book-club/book-club.tsx
@@ -6,7 +6,7 @@ import type { EventBlock } from "../events/types.ts";
 import type { UrlMetadataResponse } from "#utils/hoof/index.ts";
 import { EventChip } from "../events/components/event-chip/event-chip.tsx";
 import { LargeButton } from "#components/button/button.tsx";
-import dayjs from "dayjs";
+import { formatDate } from "#utils/date.ts";
 import { getHrefContainerProps } from "#utils/href-container-script.ts";
 import style from "./book-club.module.scss";
 
@@ -26,7 +26,11 @@ function BookClubLargeCard({ eventBlock }: BookClubLargeCardProps) {
 	return (
 		<li className={style.largeCardContainer}>
 			<p className={`text-style-headline-5 ${style.largeEventBlockDate}`}>
-				{dayjs(eventBlock.starts_at).format("dddd, MMM D")}
+				{formatDate(eventBlock.starts_at, {
+					weekday: "long",
+					month: "short",
+					day: "numeric",
+				})}
 			</p>
 			<div
 				className={style.largeCard}
@@ -65,7 +69,11 @@ function BookClubSmallCard({ eventBlock }: BookClubSmallCardProps) {
 	return (
 		<li className={style.smallCardContainer}>
 			<p className={`text-style-headline-5 ${style.smallEventBlockDate}`}>
-				{dayjs(eventBlock.starts_at).format("MMM D, YYYY")}
+				{formatDate(eventBlock.starts_at, {
+					month: "short",
+					day: "numeric",
+					year: "numeric",
+				})}
 			</p>
 			<div
 				className={style.smallCard}

--- a/src/views/events/components/calendar/calendar.tsx
+++ b/src/views/events/components/calendar/calendar.tsx
@@ -39,14 +39,15 @@ import {
 	type CalendarDate,
 	fromDate,
 	getLocalTimeZone,
+	isSameDay,
 	isSameMonth,
 	isToday,
-	parseDate,
+	startOfMonth,
 	today,
+	toCalendarDate,
 } from "@internationalized/date";
 import { filterDOMProps } from "@react-aria/utils";
 import type { Event } from "../../types.ts";
-import dayjs from "dayjs";
 import { useIsOnClient } from "../../../../hooks/use-is-on-client.ts";
 import { useReactAriaScrollGutterHack } from "../../../../hooks/useReactAriaScrollGutterHack.ts";
 import {
@@ -56,6 +57,7 @@ import {
 import type { DOMProps } from "@react-types/shared";
 import author from "#src/icons/authors.svg?raw";
 import wifi from "#src/icons/wifi.svg?raw";
+import { formatDate } from "#utils/date.ts";
 
 const CustomButton = forwardRef(
 	(
@@ -82,7 +84,7 @@ const CustomButton = forwardRef(
 
 interface CustomCalendarCellProps extends CalendarCellProps {
 	// It's a long story
-	monthDate: Date;
+	monthDate: CalendarDate;
 	popupTriggerButtonProps: DOMProps;
 }
 
@@ -99,10 +101,7 @@ export const CustomCalendarCell = forwardRef(
 	) => {
 		const state: CalendarState = useContext(CalendarStateContext);
 
-		const isOutsideMonth = !isSameMonth(
-			date,
-			fromDate(monthDate, state.timeZone),
-		);
+		const isOutsideMonth = !isSameMonth(date, monthDate);
 		const istoday = isToday(date, state.timeZone);
 
 		const buttonRef = useRef<HTMLDivElement>(null);
@@ -247,9 +246,9 @@ function CalendarDayPopup({
 						<ul role={"list"} className={style.popupContentContainer}>
 							{eventsForDate.map((event) => {
 								const firstBlockOfDay = event.blocks.find((block) => {
-									return dayjs(date.toDate(state.timeZone)).isSame(
-										block.starts_at,
-										"date",
+									return isSameDay(
+										date,
+										fromDate(block.starts_at, state.timeZone),
 									);
 								});
 
@@ -270,9 +269,11 @@ function CalendarDayPopup({
 												<span
 													className={`text-style-body-small ${style.popupContentTime}`}
 												>
-													{dayjs(firstBlockOfDay.starts_at).format(
-														"hh:mm A",
-													)}{" "}
+													{formatDate(firstBlockOfDay.starts_at, {
+														hour: "2-digit",
+														minute: "2-digit",
+														timeZone: state.timeZone,
+													})}{" "}
 												</span>
 												<span className={`text-style-body-small-bold`}>
 													{event.title}
@@ -299,7 +300,7 @@ function CalendarDayPopup({
 
 interface CustomCalendarCellWrapperProps extends CalendarCellProps {
 	events: Event[];
-	monthDate: Date;
+	monthDate: CalendarDate;
 }
 
 function CustomCalendarCellWrapper({
@@ -323,7 +324,7 @@ function CustomCalendarCellWrapper({
 	const eventsForDate = useMemo(() => {
 		return events.filter((event) =>
 			event.blocks.some((block) =>
-				dayjs(date.toDate(state.timeZone)).isSame(block.starts_at, "date"),
+				isSameDay(date, fromDate(block.starts_at, state.timeZone)),
 			),
 		);
 	}, [events, state, date]);
@@ -371,10 +372,9 @@ interface CustomCalendarGridProps extends CalendarGridProps {
 function CustomCalendarGrid({ events, ...props }: CustomCalendarGridProps) {
 	const state: CalendarState = useContext(CalendarStateContext);
 
-	const monthDate = dayjs(state.visibleRange.start.toDate(state.timeZone))
-		.startOf("month")
-		.add(props.offset?.months ?? 0, "month")
-		.toDate();
+	const monthDate = startOfMonth(state.visibleRange.start).add({
+		months: props.offset?.months ?? 0,
+	});
 
 	return (
 		<CalendarGrid {...props} className={style.grid}>
@@ -404,15 +404,27 @@ function CustomHeading() {
 	const state: CalendarState = useContext(CalendarStateContext);
 
 	const firstMonthName = useMemo(
-		() => dayjs(state.visibleRange.start.toDate(state.timeZone)).format("MMMM"),
+		() =>
+			formatDate(state.visibleRange.start.toDate(state.timeZone), {
+				month: "long",
+				timeZone: state.timeZone,
+			}),
 		[state],
 	);
 	const lastMonthName = useMemo(
-		() => dayjs(state.visibleRange.end.toDate(state.timeZone)).format("MMMM"),
+		() =>
+			formatDate(state.visibleRange.end.toDate(state.timeZone), {
+				month: "long",
+				timeZone: state.timeZone,
+			}),
 		[state],
 	);
 	const lastYearName = useMemo(
-		() => dayjs(state.visibleRange.end.toDate(state.timeZone)).format("YYYY"),
+		() =>
+			formatDate(state.visibleRange.end.toDate(state.timeZone), {
+				year: "numeric",
+				timeZone: state.timeZone,
+			}),
 		[state],
 	);
 
@@ -465,8 +477,10 @@ export function Calendar({ events }: CalendarProps) {
 
 		for (const event of events) {
 			for (const block of event.blocks) {
-				const dateString = dayjs(block.starts_at).format("YYYY-MM-DD");
-				selectedDates.set(dateString, parseDate(dateString));
+				const date = toCalendarDate(
+					fromDate(block.starts_at, getLocalTimeZone()),
+				);
+				selectedDates.set(date.toString(), date);
 			}
 		}
 

--- a/src/views/events/components/event-cards/non-recurring-event-card.tsx
+++ b/src/views/events/components/event-cards/non-recurring-event-card.tsx
@@ -1,10 +1,10 @@
-import dayjs from "dayjs";
 import type { NonRecurringEventsCardProps } from "./types.ts";
 import { getHrefContainerProps } from "#utils/href-container-script.ts";
 import date from "#src/icons/date.svg?raw";
 import style from "./non-recurring-event-card.module.scss";
 import { useMemo } from "preact/hooks";
 import { EventChip } from "../event-chip/event-chip.tsx";
+import { formatEnglishOrdinalDate } from "#utils/date.ts";
 
 export function NonRecurringEventsCard({ event }: NonRecurringEventsCardProps) {
 	// Helps us get the event with the earliest start time
@@ -52,8 +52,15 @@ export function NonRecurringEventsCard({ event }: NonRecurringEventsCardProps) {
 							dangerouslySetInnerHTML={{ __html: date }}
 						/>
 						<span>
-							{dayjs(startsAt).format("MMMM Do")} —{" "}
-							{dayjs(endsAt).format("MMMM Do")}
+							{formatEnglishOrdinalDate(startsAt, {
+								month: "long",
+								day: "numeric",
+							})}{" "}
+							—{" "}
+							{formatEnglishOrdinalDate(endsAt, {
+								month: "long",
+								day: "numeric",
+							})}
 						</span>
 					</div>
 					<ul className={style.chipsContainer} aria-label="Event type">

--- a/src/views/events/components/event-cards/recurring-event-card.tsx
+++ b/src/views/events/components/event-cards/recurring-event-card.tsx
@@ -1,10 +1,10 @@
-import dayjs from "dayjs";
 import { Button } from "#components/button/button.tsx";
 import type { RecurringEventsCardProps } from "./types.ts";
 import { getHrefContainerProps } from "#utils/href-container-script.ts";
 import date from "#src/icons/date.svg?raw";
 import style from "./recurring-event-card.module.scss";
 import { EventChip } from "../event-chip/event-chip.tsx";
+import { formatCompactTime, formatEnglishOrdinalDate } from "#utils/date.ts";
 
 export function RecurringEventsCard({
 	latestEventBlockLocationMetadata,
@@ -15,6 +15,15 @@ export function RecurringEventsCard({
 
 	const latestEventBannerSrc =
 		latestEventBlockWithMetadata?.location_metadata?.banner?.src;
+	const latestEventDate = latestEventBlockWithMetadata
+		? formatEnglishOrdinalDate(latestEventBlockWithMetadata.starts_at, {
+				month: "long",
+				day: "numeric",
+			})
+		: undefined;
+	const latestEventTime = latestEventBlockWithMetadata
+		? formatCompactTime(latestEventBlockWithMetadata.starts_at)
+		: undefined;
 
 	return (
 		<li
@@ -42,10 +51,8 @@ export function RecurringEventsCard({
 								dangerouslySetInnerHTML={{ __html: date }}
 							/>
 							<span>
-								{dayjs(latestEventBlockWithMetadata.starts_at).format(
-									"MMMM Do • h:mmA ",
-								)}
-								• <span className={style.nextEventText}>Next event</span>
+								{latestEventDate} • {latestEventTime} •{" "}
+								<span className={style.nextEventText}>Next event</span>
 							</span>
 						</div>
 					) : null}

--- a/src/views/events/constants.ts
+++ b/src/views/events/constants.ts
@@ -1,22 +1,30 @@
 import type { Event, EventBlock } from "./types.ts";
-import dayjs from "dayjs";
-import customParseFormat from "dayjs/plugin/customParseFormat";
-import utc from "dayjs/plugin/utc";
-import timezone from "dayjs/plugin/timezone";
+import { fromDate, parseDate, parseDateTime } from "@internationalized/date";
 
-dayjs.extend(customParseFormat);
-dayjs.extend(utc);
-dayjs.extend(timezone);
+const eventTimeZone = "America/Los_Angeles";
+
+const inEventTimeZone = (value: string) =>
+	parseDateTime(value).toDate(eventTimeZone);
+
+const dateInEventTimeZone = (value: string) =>
+	parseDate(value).toDate(eventTimeZone);
+
+const formatMonthDayYear = ({
+	year,
+	month,
+	day,
+}: {
+	year: number;
+	month: number;
+	day: number;
+}) =>
+	`${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}-${year}`;
 
 export const bookClubBlocks = [
 	{
 		slug: "book-club-09-25-2025",
-		starts_at: dayjs("09-25-2025 02:30 PM", "MM-DD-YYYY hh:mm A")
-			.tz("America/Los_Angeles", true)
-			.toDate(),
-		ends_at: dayjs("09-25-2025 03:30 PM", "MM-DD-YYYY hh:mm A")
-			.tz("America/Los_Angeles", true)
-			.toDate(),
+		starts_at: inEventTimeZone("2025-09-25T14:30"),
+		ends_at: inEventTimeZone("2025-09-25T15:30"),
 		location_description: "The Perils of Reactivity",
 		location_url:
 			"https://outbox.matthewphillips.info/archive/perils-of-reactivity",
@@ -25,12 +33,8 @@ export const bookClubBlocks = [
 	},
 	{
 		slug: "book-club-10-23-2025",
-		starts_at: dayjs("10-23-2025 04:30 PM", "MM-DD-YYYY hh:mm A")
-			.tz("America/Los_Angeles", true)
-			.toDate(),
-		ends_at: dayjs("10-23-2025 05:30 PM", "MM-DD-YYYY hh:mm A")
-			.tz("America/Los_Angeles", true)
-			.toDate(),
+		starts_at: inEventTimeZone("2025-10-23T16:30"),
+		ends_at: inEventTimeZone("2025-10-23T17:30"),
 		location_description: "Build Your Own Database",
 		location_url: "https://www.nan.fyi/database",
 		presenters: [],
@@ -38,12 +42,8 @@ export const bookClubBlocks = [
 	},
 	{
 		slug: "book-club-10-30-2025",
-		starts_at: dayjs("10-30-2025 04:30 PM", "MM-DD-YYYY hh:mm A")
-			.tz("America/Los_Angeles", true)
-			.toDate(),
-		ends_at: dayjs("10-30-2025 05:30 PM", "MM-DD-YYYY hh:mm A")
-			.tz("America/Los_Angeles", true)
-			.toDate(),
+		starts_at: inEventTimeZone("2025-10-30T16:30"),
+		ends_at: inEventTimeZone("2025-10-30T17:30"),
 		location_description: "An Interactive Guide to TanStack DB",
 		location_url: "https://frontendatscale.com/blog/tanstack-db/",
 		presenters: [],
@@ -51,12 +51,8 @@ export const bookClubBlocks = [
 	},
 	{
 		slug: "book-club-11-06-2025",
-		starts_at: dayjs("11-06-2025 07:30 PM", "MM-DD-YYYY hh:mm A")
-			.tz("America/Los_Angeles", true)
-			.toDate(),
-		ends_at: dayjs("11-06-2025 08:30 PM", "MM-DD-YYYY hh:mm A")
-			.tz("America/Los_Angeles", true)
-			.toDate(),
+		starts_at: inEventTimeZone("2025-11-06T19:30"),
+		ends_at: inEventTimeZone("2025-11-06T20:30"),
 		location_description: "Dithering Part 1 — Introduction",
 		location_url: "https://visualrambling.space/dithering-part-1/",
 		presenters: [],
@@ -64,12 +60,8 @@ export const bookClubBlocks = [
 	},
 	{
 		slug: "book-club-11-20-2025",
-		starts_at: dayjs("11-20-2025 04:30 PM", "MM-DD-YYYY hh:mm A")
-			.tz("America/Los_Angeles", true)
-			.toDate(),
-		ends_at: dayjs("11-20-2025 05:30 PM", "MM-DD-YYYY hh:mm A")
-			.tz("America/Los_Angeles", true)
-			.toDate(),
+		starts_at: inEventTimeZone("2025-11-20T16:30"),
+		ends_at: inEventTimeZone("2025-11-20T17:30"),
 		location_description: "A pragmatic guide to modern CSS colours - part one",
 		location_url:
 			"https://piccalil.li/blog/a-pragmatic-guide-to-modern-css-colours-part-one/",
@@ -78,12 +70,8 @@ export const bookClubBlocks = [
 	},
 	{
 		slug: "book-club-11-27-2025",
-		starts_at: dayjs("11-27-2025 04:30 PM", "MM-DD-YYYY hh:mm A")
-			.tz("America/Los_Angeles", true)
-			.toDate(),
-		ends_at: dayjs("11-27-2025 05:30 PM", "MM-DD-YYYY hh:mm A")
-			.tz("America/Los_Angeles", true)
-			.toDate(),
+		starts_at: inEventTimeZone("2025-11-27T16:30"),
+		ends_at: inEventTimeZone("2025-11-27T17:30"),
 		location_description:
 			"Unpacking Cloudflare Workers CPU Performance Benchmarks",
 		location_url:
@@ -93,12 +81,8 @@ export const bookClubBlocks = [
 	},
 	{
 		slug: "book-club-12-04-2025",
-		starts_at: dayjs("12-04-2025 04:30 PM", "MM-DD-YYYY hh:mm A")
-			.tz("America/Los_Angeles", true)
-			.toDate(),
-		ends_at: dayjs("12-04-2025 05:30 PM", "MM-DD-YYYY hh:mm A")
-			.tz("America/Los_Angeles", true)
-			.toDate(),
+		starts_at: inEventTimeZone("2025-12-04T16:30"),
+		ends_at: inEventTimeZone("2025-12-04T17:30"),
 		location_description: "Your URL Is Your State",
 		location_url: "https://alfy.blog/2025/10/31/your-url-is-your-state.html",
 		presenters: [],
@@ -106,12 +90,8 @@ export const bookClubBlocks = [
 	},
 	{
 		slug: "book-club-01-14-2026",
-		starts_at: dayjs("01-14-2026 04:30 PM", "MM-DD-YYYY hh:mm A")
-			.tz("America/Los_Angeles", true)
-			.toDate(),
-		ends_at: dayjs("01-14-2026 05:30 PM", "MM-DD-YYYY hh:mm A")
-			.tz("America/Los_Angeles", true)
-			.toDate(),
+		starts_at: inEventTimeZone("2026-01-14T16:30"),
+		ends_at: inEventTimeZone("2026-01-14T17:30"),
 		location_description: "MSW: Docs",
 		location_url: "https://mswjs.io/docs/",
 		presenters: [],
@@ -119,12 +99,8 @@ export const bookClubBlocks = [
 	},
 	{
 		slug: "book-club-01-21-2026",
-		starts_at: dayjs("01-21-2026 04:30 PM", "MM-DD-YYYY hh:mm A")
-			.tz("America/Los_Angeles", true)
-			.toDate(),
-		ends_at: dayjs("01-21-2026 05:30 PM", "MM-DD-YYYY hh:mm A")
-			.tz("America/Los_Angeles", true)
-			.toDate(),
+		starts_at: inEventTimeZone("2026-01-21T16:30"),
+		ends_at: inEventTimeZone("2026-01-21T17:30"),
 		location_description: "How to Steal Any React Component",
 		location_url: "https://fant.io/react/",
 		presenters: [],
@@ -132,12 +108,8 @@ export const bookClubBlocks = [
 	},
 	{
 		slug: "book-club-01-28-2026",
-		starts_at: dayjs("01-28-2026 04:30 PM", "MM-DD-YYYY hh:mm A")
-			.tz("America/Los_Angeles", true)
-			.toDate(),
-		ends_at: dayjs("01-28-2026 05:30 PM", "MM-DD-YYYY hh:mm A")
-			.tz("America/Los_Angeles", true)
-			.toDate(),
+		starts_at: inEventTimeZone("2026-01-28T16:30"),
+		ends_at: inEventTimeZone("2026-01-28T17:30"),
 		location_description: 'The "You" in CPU: The Basics',
 		location_url: "https://cpu.land/the-basics",
 		presenters: [],
@@ -145,12 +117,8 @@ export const bookClubBlocks = [
 	},
 	{
 		slug: "book-club-02-04-2026",
-		starts_at: dayjs("02-04-2026 04:30 PM", "MM-DD-YYYY hh:mm A")
-			.tz("America/Los_Angeles", true)
-			.toDate(),
-		ends_at: dayjs("02-04-2026 05:30 PM", "MM-DD-YYYY hh:mm A")
-			.tz("America/Los_Angeles", true)
-			.toDate(),
+		starts_at: inEventTimeZone("2026-02-04T16:30"),
+		ends_at: inEventTimeZone("2026-02-04T17:30"),
 		location_description: 'The "You" in CPU: Multitasking',
 		location_url: "https://cpu.land/slice-dat-time",
 		presenters: [],
@@ -158,12 +126,8 @@ export const bookClubBlocks = [
 	},
 	{
 		slug: "book-club-02-11-2026",
-		starts_at: dayjs("02-11-2026 04:30 PM", "MM-DD-YYYY hh:mm A")
-			.tz("America/Los_Angeles", true)
-			.toDate(),
-		ends_at: dayjs("02-11-2026 05:30 PM", "MM-DD-YYYY hh:mm A")
-			.tz("America/Los_Angeles", true)
-			.toDate(),
+		starts_at: inEventTimeZone("2026-02-11T16:30"),
+		ends_at: inEventTimeZone("2026-02-11T17:30"),
 		location_description: 'The "You" in CPU: Exec',
 		location_url: "https://cpu.land/how-to-run-a-program",
 		presenters: [],
@@ -171,12 +135,8 @@ export const bookClubBlocks = [
 	},
 	{
 		slug: "book-club-02-18-2026",
-		starts_at: dayjs("02-18-2026 04:30 PM", "MM-DD-YYYY hh:mm A")
-			.tz("America/Los_Angeles", true)
-			.toDate(),
-		ends_at: dayjs("02-18-2026 05:30 PM", "MM-DD-YYYY hh:mm A")
-			.tz("America/Los_Angeles", true)
-			.toDate(),
+		starts_at: inEventTimeZone("2026-02-18T16:30"),
+		ends_at: inEventTimeZone("2026-02-18T17:30"),
 		location_description: 'The "You" in CPU: Elf',
 		location_url: "https://cpu.land/becoming-an-elf-lord",
 		presenters: [],
@@ -184,12 +144,8 @@ export const bookClubBlocks = [
 	},
 	{
 		slug: "book-club-02-25-2026",
-		starts_at: dayjs("02-25-2026 04:30 PM", "MM-DD-YYYY hh:mm A")
-			.tz("America/Los_Angeles", true)
-			.toDate(),
-		ends_at: dayjs("02-25-2026 05:30 PM", "MM-DD-YYYY hh:mm A")
-			.tz("America/Los_Angeles", true)
-			.toDate(),
+		starts_at: inEventTimeZone("2026-02-25T16:30"),
+		ends_at: inEventTimeZone("2026-02-25T17:30"),
 		location_description: 'The "You" in CPU: Paging',
 		location_url: "https://cpu.land/the-translator-in-your-computer",
 		presenters: [],
@@ -197,12 +153,8 @@ export const bookClubBlocks = [
 	},
 	{
 		slug: "book-club-03-04-2026",
-		starts_at: dayjs("03-04-2026 04:30 PM", "MM-DD-YYYY hh:mm A")
-			.tz("America/Los_Angeles", true)
-			.toDate(),
-		ends_at: dayjs("03-04-2026 05:30 PM", "MM-DD-YYYY hh:mm A")
-			.tz("America/Los_Angeles", true)
-			.toDate(),
+		starts_at: inEventTimeZone("2026-03-04T16:30"),
+		ends_at: inEventTimeZone("2026-03-04T17:30"),
 		location_description: 'The "You" in CPU: Fork-Exec',
 		location_url: "https://cpu.land/lets-talk-about-forks-and-cows",
 		presenters: [],
@@ -210,12 +162,8 @@ export const bookClubBlocks = [
 	},
 	{
 		slug: "book-club-04-01-2026",
-		starts_at: dayjs("04-01-2026 04:30 PM", "MM-DD-YYYY hh:mm A")
-			.tz("America/Los_Angeles", true)
-			.toDate(),
-		ends_at: dayjs("04-01-2026 05:30 PM", "MM-DD-YYYY hh:mm A")
-			.tz("America/Los_Angeles", true)
-			.toDate(),
+		starts_at: inEventTimeZone("2026-04-01T16:30"),
+		ends_at: inEventTimeZone("2026-04-01T17:30"),
 		location_description: "CSS is DOOMed",
 		location_url:
 			"https://nielsleenheer.com/articles/2026/css-is-doomed-rendering-doom-in-3d-with-css/",
@@ -226,12 +174,16 @@ export const bookClubBlocks = [
 
 for (const _ of new Array(5).fill(0)) {
 	const lastEvent = bookClubBlocks.at(-1)!;
-	const starts_at = dayjs(lastEvent.starts_at).add(1, "week");
+	const startsAt = fromDate(lastEvent.starts_at, lastEvent.timezone).add({
+		weeks: 1,
+	});
 	bookClubBlocks.push({
 		...lastEvent,
-		slug: starts_at.format("MM-DD-YYYY"),
-		starts_at: starts_at.toDate(),
-		ends_at: dayjs(lastEvent.ends_at).add(1, "week").toDate(),
+		slug: formatMonthDayYear(startsAt),
+		starts_at: startsAt.toDate(),
+		ends_at: fromDate(lastEvent.ends_at, lastEvent.timezone)
+			.add({ weeks: 1 })
+			.toDate(),
 		location_description: "Discord",
 		location_url: "https://discord.playfulprogramming.com",
 	});
@@ -241,14 +193,12 @@ export const officeHoursBlocks = new Array(64).fill(0).map(
 	(_, index) =>
 		({
 			slug: "office-hours",
-			starts_at: dayjs("04-02-2026 6:00 PM", "MM-DD-YYYY hh:mm A")
-				.add(index, "week")
-				.tz("America/Los_Angeles", true)
-				.toDate(),
-			ends_at: dayjs("04-02-2027 6:00 PM", "MM-DD-YYYY hh:mm A")
-				.add(index, "week")
-				.tz("America/Los_Angeles", true)
-				.toDate(),
+			starts_at: parseDateTime("2026-04-02T18:00")
+				.add({ weeks: index })
+				.toDate(eventTimeZone),
+			ends_at: parseDateTime("2027-04-02T18:00")
+				.add({ weeks: index })
+				.toDate(eventTimeZone),
 			location_description: "Discord",
 			location_url: "https://discord.playfulprogramming.com",
 			presenters: [],
@@ -259,12 +209,8 @@ export const officeHoursBlocks = new Array(64).fill(0).map(
 export const SacramentoBootcampBlocks = [
 	{
 		slug: "sacramento-bootcamp-2026-01",
-		starts_at: dayjs("01-06-2026", "MM-DD-YYYY")
-			.tz("America/Los_Angeles", true)
-			.toDate(),
-		ends_at: dayjs("03-24-2026", "MM-DD-YYYY")
-			.tz("America/Los_Angeles", true)
-			.toDate(),
+		starts_at: dateInEventTimeZone("2026-01-06"),
+		ends_at: dateInEventTimeZone("2026-03-24"),
 		location_description: "Sacramento, CA",
 		timezone: "America/Los_Angeles",
 		presenters: [],

--- a/src/views/events/events-page.tsx
+++ b/src/views/events/events-page.tsx
@@ -11,13 +11,9 @@ import { Calendar } from "./components/calendar/calendar.tsx";
 import { LongWave } from "./components/long-wave/long-wave.tsx";
 import filter from "#src/icons/filter.svg?raw";
 import style from "./events-page.module.scss";
-import dayjs from "dayjs";
-import advancedFormat from "dayjs/plugin/advancedFormat";
 import type { LatestEventBlockLocationMetadataType } from "./components/event-cards/types.ts";
 import { RecurringEventsCard } from "./components/event-cards/recurring-event-card.tsx";
 import { NonRecurringEventsCard } from "./components/event-cards/non-recurring-event-card.tsx";
-
-dayjs.extend(advancedFormat);
 
 type EventType = "all" | "online" | "in-person";
 


### PR DESCRIPTION
It's been baseline'd since last year; so it should be safe to adopt now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved date and time formatting across blog posts, events, book clubs, and embedded content.
  * Event calendars and schedules now provide more consistent timezone-aware dates and times.
  * Invalid embedded dates are handled gracefully while preserving the original date text.
  * Date displays now support ordinal day formatting and clearer event time presentation.

* **Bug Fixes**
  * Corrected handling of local date-only values and dates from years before 100.

* **Tests**
  * Added coverage for date formatting, local-time parsing, ordinal dates, and compact event times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->