### PR TITLE
Only enable analytics in prod

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -58,19 +58,26 @@ server {
         add_header Cache-Control "public, max-age=31536000, immutable";
     }
 
-	# Needed for Plausible Analytics
-    resolver 9.9.9.9; # Use quad9 DNS resolver. Remove this line if you've already configured a DNS resolver.
+	# Resolve Plausible through Fly's in-machine DNS. Public DNS can be
+	# unreachable from review machines and otherwise holds the request open for
+	# nginx's 30-second default resolver timeout.
+    resolver [fdaa::3] valid=300s;
+    resolver_timeout 5s;
     set $plausible_script_url https://plausible.io/js/script.outbound-links.local.js;
     set $plausible_event_url https://plausible.io/api/event;
 
  	location = /areyoumyuser/js/script.js {
         proxy_pass $plausible_script_url;
         proxy_set_header Host plausible.io;
+        proxy_ssl_server_name on;
+        proxy_ssl_name plausible.io;
     }
 
     location = /areyoumyuser/api/event {
         proxy_pass $plausible_event_url;
         proxy_set_header Host plausible.io;
+        proxy_ssl_server_name on;
+        proxy_ssl_name plausible.io;
         proxy_buffering on;
         proxy_http_version 1.1;
 

--- a/src/layouts/barebones.astro
+++ b/src/layouts/barebones.astro
@@ -12,6 +12,15 @@ interface DocumentProps {
 
 let { lang } = Astro.props as DocumentProps;
 lang ??= "en";
+
+const enableAnalytics = import.meta.env.MODE === "production";
+const analyticsSetupScript = `
+	window.plausible =
+		window.plausible ||
+		function (...args) {
+			(window.plausible.q = window.plausible.q || []).push(args);
+		};
+`;
 ---
 
 <html lang={lang} class="light">
@@ -72,19 +81,22 @@ lang ??= "en";
 			href="/icons/icon-512x512.png?v=2a"
 		/>
 		<script defer src="/uninstall-sw.js" is:inline></script>
-		<script
-			is:inline
-			defer
-			data-domain="playfulprogramming.com"
-			src="/areyoumyuser/js/script.js"
-			data-api="/areyoumyuser/api/event"></script>
-		<script is:inline>
-			window.plausible =
-				window.plausible ||
-				function (...args) {
-					(window.plausible.q = window.plausible.q || []).push(args);
-				};
-		</script>
+		{
+			enableAnalytics && (
+				<script
+					is:inline
+					async
+					data-domain="playfulprogramming.com"
+					src="/areyoumyuser/js/script.js"
+					data-api="/areyoumyuser/api/event"
+				/>
+			)
+		}
+		{
+			enableAnalytics && (
+				<script is:inline set:html={analyticsSetupScript} />
+			)
+		}
 		<slot name="head" />
 	</head>
 	<body>


### PR DESCRIPTION
This PR fixes an issue that was present on preview envs but not caught until we added a script that loaded in preview envs like #1635

Basically, it was failing to load our analytics and therefore waiting 30s to finish loading any other script passed after-the-fact.

This PR fixes that

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Analytics now loads only in production environments.
  - Analytics scripts load asynchronously when enabled, improving page loading behavior.

- **Bug Fixes**
  - Improved Plausible proxy connectivity using Fly’s DNS resolver and a defined timeout.
  - Enabled secure TLS routing for Plausible requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->