### PR TITLE
Move Astro components to `Props`

### DIFF
--- a/src/components/contributor-card/contributor-card.astro
+++ b/src/components/contributor-card/contributor-card.astro
@@ -8,7 +8,7 @@ import { getHrefContainerProps } from "../../utils/href-container-script.ts";
 import allRoles from "../../../content/data/roles.json" with { type: "json" };
 import { tabletSmall } from "../../tokens/breakpoints.ts";
 
-interface CardProps {
+interface Props {
 	person: PersonInfo;
 	overrides?: {
 		roles?: string[];
@@ -16,7 +16,7 @@ interface CardProps {
 	};
 }
 
-const { person, overrides } = Astro.props as CardProps;
+const { person, overrides } = Astro.props;
 const personHref = `/people/${person.id}`;
 
 const roles =

--- a/src/components/page-card/page-card.astro
+++ b/src/components/page-card/page-card.astro
@@ -1,7 +1,7 @@
 ---
 import styles from "./page-card.module.scss";
 
-interface PageCardProps {
+interface Props {
 	title: string;
 	description: string;
 	imageSrc: astroHTML.JSX.ImgHTMLAttributes["src"];
@@ -9,8 +9,7 @@ interface PageCardProps {
 	numberOfButtons?: number;
 }
 
-const { title, description, imageAlt, imageSrc, numberOfButtons } =
-	Astro.props as PageCardProps;
+const { title, description, imageAlt, imageSrc, numberOfButtons } = Astro.props;
 ---
 
 <div class={styles.pageCardContainer}>

--- a/src/components/related-posts/related-posts-card.astro
+++ b/src/components/related-posts/related-posts-card.astro
@@ -3,13 +3,13 @@ import style from "./related-posts-card.module.scss";
 import { getHrefContainerProps } from "#utils/href-container-script.ts";
 import type { PersonInfo } from "../../types/PersonInfo.ts";
 
-interface RelatedPostsCardProps {
+interface Props {
 	title: string;
 	slug: string;
 	authors: PersonInfo[];
 }
 
-const { title, slug, authors } = Astro.props as RelatedPostsCardProps;
+const { title, slug, authors } = Astro.props;
 ---
 
 <li {...getHrefContainerProps(`/posts/${slug}`)} class={style.container}>

--- a/src/components/related-posts/related-posts.astro
+++ b/src/components/related-posts/related-posts.astro
@@ -6,12 +6,12 @@ import * as api from "#utils/api.ts";
 import { getSuggestedArticles } from "#utils/get-suggested-articles.ts";
 import { isDefined } from "#utils/is-defined.ts";
 
-interface RelatedPostsProps {
+interface Props {
 	post: PostInfo;
 	headingId: string;
 }
 
-const { post, headingId } = Astro.props as RelatedPostsProps;
+const { post, headingId } = Astro.props;
 const suggestedArticles = getSuggestedArticles(post);
 
 function getPostAuthors(post: PostInfo) {

--- a/src/layouts/barebones.astro
+++ b/src/layouts/barebones.astro
@@ -6,11 +6,11 @@ import type { Languages } from "#types/index.ts";
  * For our super custom pages that don't require the global styling of the rest of UU, such as FFG's pages.
  */
 
-interface DocumentProps {
+interface Props {
 	lang?: Languages;
 }
 
-let { lang } = Astro.props as DocumentProps;
+let { lang } = Astro.props;
 lang ??= "en";
 ---
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,6 +16,10 @@ const collectionsToDisplay = getCollectionsByLang(locale).slice(0, 4);
 <Document>
 	<SEO slot="head" title="Homepage" />
 	<main class="container">
-		<Homepage posts={postsToDisplay} collections={collectionsToDisplay} />
+		<Homepage
+			posts={postsToDisplay}
+			collections={collectionsToDisplay}
+			locale={locale}
+		/>
 	</main>
 </Document>

--- a/src/views/base/translations/translations-header.astro
+++ b/src/views/base/translations/translations-header.astro
@@ -9,11 +9,11 @@ import {
 import style from "./translations-header.module.scss";
 import { Icon } from "astro-icon/components";
 
-interface TranslationsHeaderProps {
+interface Props {
 	locales: Languages[];
 }
 
-const props = Astro.props as TranslationsHeaderProps;
+const props = Astro.props;
 const path = removePrefixLanguageFromPath(Astro.url.pathname);
 const currentLocale = getPrefixLanguageFromPath(Astro.url.pathname);
 

--- a/src/views/blog-post/blog-post-layout/blog-post-layout.astro
+++ b/src/views/blog-post/blog-post-layout/blog-post-layout.astro
@@ -1,11 +1,11 @@
 ---
 import style from "./blog-post-layout.module.scss";
 
-interface BlogPostLayoutProps {
+interface Props {
 	hideLeftSidebar?: boolean;
 }
 
-const { hideLeftSidebar } = Astro.props as BlogPostLayoutProps;
+const { hideLeftSidebar } = Astro.props;
 ---
 
 <div class={style.mobileMenu}>

--- a/src/views/blog-post/blog-post.astro
+++ b/src/views/blog-post/blog-post.astro
@@ -95,7 +95,7 @@ const GHLink = `https://github.com/${siteMetadata.repoPath}/tree/main/content/${
 				post.collection ? (
 					<SeriesToC
 						post={post}
-						postSeries={collectionPosts}
+						postSeries={collectionPosts!}
 						collection={collection}
 					/>
 				) : null

--- a/src/views/blog-post/series/series-toc.astro
+++ b/src/views/blog-post/series/series-toc.astro
@@ -8,13 +8,13 @@ import type { CollectionInfo } from "#types/CollectionInfo.ts";
 import { translate } from "#utils/index.ts";
 import { getShortTitle } from "../../../utils/remove-article-collection-prefix.ts";
 
-interface SeriesTocProps {
+interface Props {
 	post: PostInfo;
 	postSeries: PostInfo[];
 	collection?: CollectionInfo;
 }
 
-const { post, postSeries, collection } = Astro.props as SeriesTocProps;
+const { post, postSeries, collection } = Astro.props;
 
 const activePostsMeta = findActivePost(post, postSeries);
 

--- a/src/views/blog-post/table-of-contents/mobile/table-of-contents-mobile.astro
+++ b/src/views/blog-post/table-of-contents/mobile/table-of-contents-mobile.astro
@@ -8,11 +8,11 @@ import { Icon } from "astro-icon/components";
 import MobileHeadingIntersectionObserverScript from "./mobile-heading-intersection-observer-script.astro";
 import MobileTableOfContentsTitleScrollObserver from "./mobile-table-of-contents-title-scroll-observer.astro";
 
-interface TableOfContentsProps {
+interface Props {
 	headingsWithId: PostHeadingInfo[];
 }
 
-const { headingsWithId } = Astro.props as TableOfContentsProps;
+const { headingsWithId } = Astro.props;
 
 const headings = headingsWithId?.length ? headingsWithId : [];
 

--- a/src/views/blog-post/table-of-contents/table-of-contents.astro
+++ b/src/views/blog-post/table-of-contents/table-of-contents.astro
@@ -4,11 +4,11 @@ import classnames from "classnames";
 import type { PostHeadingInfo } from "#types/index.ts";
 import HeadingIntersectionObserverScript from "./heading-intersection-observer-script.astro";
 
-interface TableOfContentsProps {
+interface Props {
 	headingsWithId: PostHeadingInfo[];
 }
 
-const { headingsWithId } = Astro.props as TableOfContentsProps;
+const { headingsWithId } = Astro.props;
 
 const headings = headingsWithId?.length ? headingsWithId : [];
 

--- a/src/views/collections/art-of-accessibility/segments/top-contents.astro
+++ b/src/views/collections/art-of-accessibility/segments/top-contents.astro
@@ -42,5 +42,9 @@ const tags: TagList = [
 	are inclusive and accessible; all while using cutting edge web-tech.
 </p>
 <div class="section-chip-group-container" data-no-max-width>
-	<ChipGroup tags={tags} rows={1} />
+	<ChipGroup
+		tags={tags}
+		rows={1}
+		ariaLabel="Subjects taught in Art of Accessibility"
+	/>
 </div>

--- a/src/views/collections/big-bot-builders/segments/top-contents.astro
+++ b/src/views/collections/big-bot-builders/segments/top-contents.astro
@@ -40,5 +40,9 @@ const tags: TagList = [
 	like.
 </p>
 <div class="section-chip-group-container" data-no-max-width>
-	<ChipGroup tags={tags} rows={1} />
+	<ChipGroup
+		tags={tags}
+		rows={1}
+		ariaLabel="Subjects taught in Big Bot Builders"
+	/>
 </div>

--- a/src/views/collections/framework-field-guide-ecosystem/components/collection-table-of-contents-ecosystem.astro
+++ b/src/views/collections/framework-field-guide-ecosystem/components/collection-table-of-contents-ecosystem.astro
@@ -7,8 +7,7 @@ interface ChapterList {
 	description: string;
 	order: string;
 }
-
-interface CollectionTableOfContentsProps {
+interface Props {
 	title?: string;
 	posts: PostInfo[];
 	chapterList?: ChapterList[];
@@ -17,7 +16,7 @@ interface CollectionTableOfContentsProps {
 }
 
 const { title, posts, chapterList, chaptersToShow, postPrefixToRemove } =
-	Astro.props as CollectionTableOfContentsProps;
+	Astro.props;
 
 const maxChapterToShow = chaptersToShow ?? 10;
 
@@ -76,7 +75,7 @@ function removeTitlePrefix(title: string) {
 					const i = (posts?.length ?? 0) + _i;
 					const shouldHideInitially = i >= maxChapterToShow;
 					const isLastVisible = i === maxChapterToShow - 1;
-					const isNumber = /\d/.test(post.order);
+					const isNumber = /\d/.test(String(post.order));
 					return (
 						<li
 							class={styles.postContainer}

--- a/src/views/collections/framework-field-guide-ecosystem/components/collection-table-of-contents-ecosystem.astro
+++ b/src/views/collections/framework-field-guide-ecosystem/components/collection-table-of-contents-ecosystem.astro
@@ -1,16 +1,12 @@
 ---
+import type { FuturePost } from "#types/CollectionInfo.ts";
 import type { PostInfo } from "#types/PostInfo.ts";
 import styles from "./collection-table-of-contents-ecosystem.module.scss";
 
-interface ChapterList {
-	title: string;
-	description: string;
-	order: string;
-}
 interface Props {
 	title?: string;
 	posts: PostInfo[];
-	chapterList?: ChapterList[];
+	chapterList?: FuturePost[];
 	chaptersToShow?: number;
 	postPrefixToRemove?: string;
 }

--- a/src/views/collections/framework-field-guide-ecosystem/segments/ecosystem-ecosystem.astro
+++ b/src/views/collections/framework-field-guide-ecosystem/segments/ecosystem-ecosystem.astro
@@ -5,6 +5,7 @@ import WhatYouNeed from "../components/what-you-need.astro";
 import CollectionTableOfContents from "../components/collection-table-of-contents-ecosystem.astro";
 import BottomContents from "./bottom-contents.astro";
 import { getCollectionBySlug, getPostsByCollection } from "#utils/api.ts";
+import type { FuturePost } from "#types/CollectionInfo.ts";
 
 const collection = getCollectionBySlug("framework-field-guide-ecosystem", "en");
 
@@ -26,7 +27,7 @@ const chapterList = getPostsByCollection(
 			<CollectionTableOfContents
 				title="Chapters*"
 				chaptersToShow={5}
-				chapterList={collection!.chapterList}
+				chapterList={collection!.chapterList as FuturePost[]}
 				posts={chapterList}
 			/>
 			<BottomContents />

--- a/src/views/collections/framework-field-guide-fundamentals/components/collection-table-of-contents-fundamentals.astro
+++ b/src/views/collections/framework-field-guide-fundamentals/components/collection-table-of-contents-fundamentals.astro
@@ -8,7 +8,7 @@ interface ChapterList {
 	order: string;
 }
 
-interface CollectionTableOfContentsProps {
+interface Props {
 	title?: string;
 	posts: PostInfo[];
 	chapterList?: ChapterList[];
@@ -17,7 +17,7 @@ interface CollectionTableOfContentsProps {
 }
 
 const { title, posts, chapterList, chaptersToShow, postPrefixToRemove } =
-	Astro.props as CollectionTableOfContentsProps;
+	Astro.props;
 
 const maxChapterToShow = chaptersToShow ?? 10;
 

--- a/src/views/collections/framework-field-guide-fundamentals/components/collection-table-of-contents-fundamentals.astro
+++ b/src/views/collections/framework-field-guide-fundamentals/components/collection-table-of-contents-fundamentals.astro
@@ -1,17 +1,12 @@
 ---
+import type { FuturePost } from "#types/CollectionInfo.ts";
 import type { PostInfo } from "#types/PostInfo.ts";
 import styles from "./collection-table-of-contents-fundamentals.module.scss";
-
-interface ChapterList {
-	title: string;
-	description: string;
-	order: string;
-}
 
 interface Props {
 	title?: string;
 	posts: PostInfo[];
-	chapterList?: ChapterList[];
+	chapterList?: FuturePost[];
 	chaptersToShow?: number;
 	postPrefixToRemove?: string;
 }
@@ -76,7 +71,7 @@ function removeTitlePrefix(title: string) {
 					const i = (posts?.length ?? 0) + _i;
 					const shouldHideInitially = i >= maxChapterToShow;
 					const isLastVisible = i === maxChapterToShow - 1;
-					const isNumber = /\d/.test(post.order);
+					const isNumber = /\d/.test(post.order as unknown as string);
 					return (
 						<li
 							class={styles.postContainer}

--- a/src/views/collections/framework-field-guide/components/book-cover-container.astro
+++ b/src/views/collections/framework-field-guide/components/book-cover-container.astro
@@ -1,9 +1,9 @@
 ---
-interface BookCoverContainerProps {
+interface Props {
 	class?: string;
 }
 
-const { class: className } = Astro.props as BookCoverContainerProps;
+const { class: className } = Astro.props;
 ---
 
 <div class={`bookCoverContainer ${className ? className : ""}`}>

--- a/src/views/collections/framework-field-guide/components/book-cover-layer.astro
+++ b/src/views/collections/framework-field-guide/components/book-cover-layer.astro
@@ -1,15 +1,11 @@
 ---
-interface BookCoverLayerProps {
+interface Props {
 	class?: string;
 	moveOnScrollBy?: number;
 	name?: string;
 }
 
-const {
-	class: className,
-	moveOnScrollBy,
-	name,
-} = Astro.props as BookCoverLayerProps;
+const { class: className, moveOnScrollBy, name } = Astro.props;
 ---
 
 <div

--- a/src/views/collections/framework-field-guide/components/chip-group.astro
+++ b/src/views/collections/framework-field-guide/components/chip-group.astro
@@ -43,7 +43,7 @@ const uniqueTags = Array.from(new Set(tagTable.flat()));
 			tagTable.map((_, i) => (
 				<InfiniteLoopSlider
 					duration={random(MIN_DURATION, MAX_DURATION)}
-					reverse={i % 2}
+					reverse={(i % 2) === 1}
 				>
 					{tagTable[i].map((tag) => (
 						<li class="text-style-body-medium-bold tag">{tag}</li>

--- a/src/views/collections/framework-field-guide/components/chip-group.astro
+++ b/src/views/collections/framework-field-guide/components/chip-group.astro
@@ -18,13 +18,13 @@ const TAGS_PER_ROW = 10;
 
 export type TagList = Readonly<FixedArray<string, 30>>;
 
-interface ChipGroupProps {
+interface Props {
 	tags: TagList;
 	ariaLabel: string;
 	rows?: number;
 }
 
-const { tags, ariaLabel, rows } = Astro.props as ChipGroupProps;
+const { tags, ariaLabel, rows } = Astro.props;
 const ROWS = rows ?? 3;
 const SHUFFLED_TAGS = shuffle(tags);
 const tagTable = [...new Array(ROWS)].map((_, i) =>

--- a/src/views/collections/framework-field-guide/components/infinite-loop-slider.astro
+++ b/src/views/collections/framework-field-guide/components/infinite-loop-slider.astro
@@ -1,10 +1,10 @@
 ---
-interface InfiniteLoopSliderProps {
+interface Props {
 	duration: number;
 	reverse: boolean;
 }
 
-const { duration, reverse = false } = Astro.props as InfiniteLoopSliderProps;
+const { duration, reverse = false } = Astro.props;
 ---
 
 <div

--- a/src/views/collections/framework-field-guide/components/prominent-quote.astro
+++ b/src/views/collections/framework-field-guide/components/prominent-quote.astro
@@ -3,7 +3,7 @@ import { Picture } from "#components/image/picture.tsx";
 import styles from "./prominent-quote.module.scss";
 import type { ImageMetadata } from "astro";
 
-interface QuoteCardProps {
+interface Props {
 	avatarSrc: string | Promise<{ default: ImageMetadata }>;
 	quote: string;
 	personLink: string;
@@ -11,8 +11,7 @@ interface QuoteCardProps {
 	personName: string;
 }
 
-const { avatarSrc, quote, personLink, personTitle, personName } =
-	Astro.props as QuoteCardProps;
+const { avatarSrc, quote, personLink, personTitle, personName } = Astro.props;
 
 const src =
 	typeof avatarSrc === "string" ? avatarSrc : (await avatarSrc).default;

--- a/src/views/collections/framework-field-guide/components/section-metric.astro
+++ b/src/views/collections/framework-field-guide/components/section-metric.astro
@@ -1,13 +1,12 @@
 ---
-interface SectionMetricProps {
+interface Props {
 	numberStr: string;
 	asterisk: boolean;
 	subtitle: string;
 	ariaLabel: string;
 }
 
-const { numberStr, subtitle, asterisk, ariaLabel } =
-	Astro.props as SectionMetricProps;
+const { numberStr, subtitle, asterisk, ariaLabel } = Astro.props;
 ---
 
 <div class="section-metric-container" aria-label={ariaLabel}>

--- a/src/views/explore/homepage.astro
+++ b/src/views/explore/homepage.astro
@@ -12,13 +12,13 @@ import { buildSearchQuery } from "#src/views/search/search.ts";
 import * as api from "#utils/api.ts";
 import { isDefined } from "#utils/is-defined.ts";
 
-export interface HomepageProps {
+export interface Props {
 	posts: PostInfo[];
 	collections: CollectionInfo[];
 	locale: Languages;
 }
 
-const { posts, collections, locale } = Astro.props as HomepageProps;
+const { posts, collections, locale } = Astro.props;
 
 const postAuthors = new Map(
 	[...new Set(posts.flatMap((p) => p.authors))]

--- a/src/views/person/components/achievement-card.astro
+++ b/src/views/person/components/achievement-card.astro
@@ -2,11 +2,11 @@
 import styles from "./achievements.module.scss";
 import type { AchievementsInfo } from "#types/AchievementsInfo.ts";
 
-interface AchievementsProps {
+interface Props {
 	achievement: AchievementsInfo;
 }
 
-const { achievement } = Astro.props as AchievementsProps;
+const { achievement } = Astro.props;
 ---
 
 <div class={styles.container}>

--- a/src/views/person/components/profile-section.astro
+++ b/src/views/person/components/profile-section.astro
@@ -7,11 +7,11 @@ import * as api from "#utils/api.ts";
 import { isDefined } from "#utils/is-defined.ts";
 import { desktopSmall, tabletSmall } from "#src/tokens/breakpoints.ts";
 
-interface ProfileSectionProps {
+interface Props {
 	person: PersonInfo;
 }
 
-const { person } = Astro.props as ProfileSectionProps;
+const { person } = Astro.props;
 
 const iconSize = 20;
 

--- a/src/views/person/person-page.astro
+++ b/src/views/person/person-page.astro
@@ -7,7 +7,7 @@ import { Button } from "#components/button/button.tsx";
 import styles from "./person-page.module.scss";
 import AchievementCard from "./components/achievement-card.astro";
 import { buildSearchQuery } from "../search/search.ts";
-import type { Achievement } from "#src/utils/achievements/index.ts";
+import type { AchievementsInfo } from "#types/AchievementsInfo.ts";
 import { getAchievements } from "#src/utils/achievements/index.ts";
 import { translate } from "#utils/translations.ts";
 import * as api from "#utils/api.ts";
@@ -68,7 +68,7 @@ const postAuthors = new Map(
 							data-hide-initially={!shouldShow}
 							style={shouldShow ? "" : "display: none;"}
 						>
-							<AchievementCard achievement={ach} />
+							<AchievementCard achievement={ach as AchievementsInfo} />
 						</li>
 					);
 				})

--- a/src/views/person/person-page.astro
+++ b/src/views/person/person-page.astro
@@ -13,12 +13,12 @@ import { translate } from "#utils/translations.ts";
 import * as api from "#utils/api.ts";
 import { isDefined } from "#utils/is-defined.ts";
 
-interface UnicornPageProps {
+interface Props {
 	person: PersonInfo;
 	posts: PostInfo[];
 }
 
-const { person, posts } = Astro.props as UnicornPageProps;
+const { person, posts } = Astro.props;
 
 const achievementsMeta = await getAchievements(person);
 


### PR DESCRIPTION
This PR moves `as CompType` to rename `CompType` to `Props`. This makes `astro check` work better and removes type casting.