### PR TITLE
fix: preserve markdown fragment targets

### DIFF
--- a/e2e/tests/posts-example.spec.ts
+++ b/e2e/tests/posts-example.spec.ts
@@ -49,3 +49,39 @@ test("posts/example renders dark mode", async ({ page }) => {
 		maxDiffPixels: MAX_DIFF_PIXELS,
 	});
 });
+
+test("posts/example fragment links resolve", async ({ page }) => {
+	await page.goto("/posts/example", { waitUntil: "networkidle" });
+
+	const unresolvedFragments = await page
+		.getByTestId("post-body-div")
+		.locator('a[href^="#"]')
+		.evaluateAll((links) =>
+			links.flatMap((link) => {
+				const href = link.getAttribute("href");
+				if (!href || href === "#") return [];
+
+				const fragment = href.slice(1);
+				let decodedFragment = fragment;
+				try {
+					decodedFragment = decodeURIComponent(fragment);
+				} catch {
+					// A malformed escape cannot match a decoded ID.
+				}
+
+				return document.getElementById(fragment) ||
+					document.getElementById(decodedFragment)
+					? []
+					: [href];
+			}),
+		);
+
+	expect(unresolvedFragments).toEqual([]);
+	await expect(page.locator("#why-does-js")).toHaveText(
+		"Based on what you’ve seen: Why does JS?",
+	);
+	await expect(page.locator("#why-does-js")).toBeVisible();
+	await expect(page.getByRole("radiogroup").first()).toHaveAccessibleName(
+		"Based on what you’ve seen: Why does JS?",
+	);
+});

--- a/src/components/quiz-radio/quiz-radio-inline.tsx
+++ b/src/components/quiz-radio/quiz-radio-inline.tsx
@@ -8,6 +8,7 @@ export interface QuizRadioInlineProps {
 	id: string;
 	quizId?: string;
 	title: string;
+	titleId?: string;
 	options: QuizRadioOption[];
 	questionNum: number;
 	totalNum: number;
@@ -74,6 +75,7 @@ export function QuizRadioInline(props: QuizRadioInlineProps) {
 		<QuizRadio
 			id={props.id}
 			title={props.title}
+			titleId={props.titleId}
 			options={options}
 			questionNum={props.questionNum}
 			totalNum={props.totalNum}

--- a/src/components/quiz-radio/quiz-radio.tsx
+++ b/src/components/quiz-radio/quiz-radio.tsx
@@ -30,6 +30,7 @@ export interface QuizRadioOption {
 export interface QuizRadioProps {
 	id?: string;
 	title: string;
+	titleId?: string;
 	options: QuizRadioOption[];
 	questionNum: number;
 	totalNum: number;
@@ -74,7 +75,7 @@ export function QuizRadio(props: QuizRadioProps) {
 					<span class="text-style-body-medium-bold">{props.totalNum}</span>
 				</span>
 				<Label className={`${style.quizOptionTitle} text-style-headline-5`}>
-					{props.title}
+					<span id={props.titleId}>{props.title}</span>
 				</Label>
 				<span class={`${style.quizPrompt} text-style-body-medium-bold`}>
 					Select the correct answer.

--- a/src/utils/markdown/components/components.ts
+++ b/src/utils/markdown/components/components.ts
@@ -38,6 +38,8 @@ export interface ComponentNode<Props = object> extends hast.Node {
 	component: keyof typeof components;
 	props: Omit<Props, "children">;
 	children: (PlayfulNode | hast.ElementContent)[];
+	/** IDs that the rendered component exposes as URL fragment targets. */
+	fragmentIds?: string[];
 }
 
 export type PlayfulNode =

--- a/src/utils/markdown/components/quiz/rehype-transform-quiz-radio.ts
+++ b/src/utils/markdown/components/quiz/rehype-transform-quiz-radio.ts
@@ -56,6 +56,10 @@ export const transformQuizRadio: RehypeFunctionComponent = ({
 		return [];
 	}
 	const title = toString(titleNode);
+	const titleId =
+		typeof titleNode.properties["id"] === "string"
+			? titleNode.properties["id"]
+			: undefined;
 
 	const listNode = findListNode(children);
 	if (!listNode) {
@@ -120,19 +124,23 @@ export const transformQuizRadio: RehypeFunctionComponent = ({
 		(child) => child.type != "text" || child.value.trim().length > 0,
 	);
 
-	return [
-		createComponent(
-			"QuizRadio",
-			{
-				id: attributes.id,
-				quizId,
-				title,
-				options,
-				questionNum: Number(attributes["question-num"]),
-				totalNum: Number(attributes["total-num"]),
-				isIndividualSubmit: quizId === undefined,
-			},
-			hasChildren ? localChildren : undefined,
-		),
-	];
+	const component = createComponent(
+		"QuizRadio",
+		{
+			id: attributes.id,
+			quizId,
+			title,
+			titleId,
+			options,
+			questionNum: Number(attributes["question-num"]),
+			totalNum: Number(attributes["total-num"]),
+			isIndividualSubmit: quizId === undefined,
+		},
+		hasChildren ? localChildren : undefined,
+	);
+	component.fragmentIds = [attributes.id, titleId].filter(
+		(id): id is string => typeof id === "string",
+	);
+
+	return [component];
 };

--- a/src/utils/markdown/rehype-validate-heading-links.node.spec.ts
+++ b/src/utils/markdown/rehype-validate-heading-links.node.spec.ts
@@ -1,0 +1,120 @@
+import type { Element, Root } from "hast";
+import { unified } from "unified";
+import { VFile } from "vfile";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { rehypeValidateHeadingLinks } from "./rehype-validate-heading-links.ts";
+import type { MarkdownVFile } from "./types.ts";
+
+function markdownFile(headingSlugs: string[] = []): MarkdownVFile {
+	return new VFile({
+		value: "",
+		path: "/content/test/index.md",
+		data: {
+			kind: "post",
+			file: "/content/test/index.md",
+			headingsWithIds: headingSlugs.map((slug) => ({
+				value: slug,
+				depth: 2,
+				slug,
+			})),
+			snitips: new Map(),
+		},
+	}) as MarkdownVFile;
+}
+
+async function validate(tree: Root, file = markdownFile()): Promise<void> {
+	await unified().use(rehypeValidateHeadingLinks).run(tree, file);
+}
+
+function anchor(href: string, id?: string): Element {
+	return {
+		type: "element",
+		tagName: "a",
+		properties: { href, ...(id ? { id } : {}) },
+		children: [],
+	};
+}
+
+describe("rehypeValidateHeadingLinks", () => {
+	beforeEach(() => {
+		vi.spyOn(console, "log").mockImplementation(() => undefined);
+		vi.spyOn(console, "error").mockImplementation(() => undefined);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	test("accepts links to final element and component IDs", async () => {
+		const tree = {
+			type: "root",
+			children: [
+				{
+					type: "element",
+					tagName: "span",
+					properties: { id: "cool-id🦦🦦🦦" },
+					children: [],
+				},
+				anchor("#cool-id%F0%9F%A6%A6%F0%9F%A6%A6%F0%9F%A6%A6"),
+				{
+					type: "element",
+					tagName: "li",
+					properties: { id: "user-content-fn-1" },
+					children: [],
+				},
+				anchor("#user-content-fn-1", "user-content-fnref-1"),
+				anchor("#user-content-fnref-1"),
+				{
+					type: "playful-component",
+					component: "QuizRadio",
+					props: {},
+					fragmentIds: ["why-does-js"],
+					children: [],
+				},
+				anchor("#why-does-js"),
+			],
+		} as unknown as Root;
+
+		await validate(tree);
+
+		expect(console.error).not.toHaveBeenCalled();
+	});
+
+	test("corrects the case of links to headings", async () => {
+		const link = anchor("#mixed-case-heading");
+		const tree: Root = {
+			type: "root",
+			children: [
+				{
+					type: "element",
+					tagName: "h2",
+					properties: { id: "Mixed-Case-Heading" },
+					children: [],
+				},
+				link,
+			],
+		};
+
+		await validate(tree, markdownFile(["Mixed-Case-Heading"]));
+
+		expect(link.properties["href"]).toBe("#Mixed-Case-Heading");
+		expect(console.error).toHaveBeenCalledOnce();
+		expect(vi.mocked(console.error).mock.calls.flat().join(" ")).toContain(
+			"has wrong case",
+		);
+	});
+
+	test("reports genuinely missing and malformed fragment targets", async () => {
+		const tree: Root = {
+			type: "root",
+			children: [anchor("#missing"), anchor("#bad%escape")],
+		};
+
+		await validate(tree);
+
+		expect(console.error).toHaveBeenCalledTimes(2);
+		expect(vi.mocked(console.error).mock.calls.flat().join(" ")).toContain(
+			'Unknown anchor link to heading "#missing"',
+		);
+	});
+});

--- a/src/utils/markdown/rehype-validate-heading-links.ts
+++ b/src/utils/markdown/rehype-validate-heading-links.ts
@@ -1,11 +1,26 @@
-import type { Root } from "hast";
+import type { Element, Root } from "hast";
 import type { Plugin } from "unified";
 import { visit } from "unist-util-visit";
 import { isMarkdownVFile } from "./types.ts";
 import { logError } from "./logger.ts";
 
+type NodeWithFragmentIds = {
+	fragmentIds?: unknown;
+};
+
+function fragmentCandidates(fragment: string): string[] {
+	try {
+		const decodedFragment = decodeURIComponent(fragment);
+		return decodedFragment === fragment
+			? [fragment]
+			: [fragment, decodedFragment];
+	} catch {
+		return [fragment];
+	}
+}
+
 /**
- * Plugin to validate anchor links to headings and ensure their case matches their target heading IDs.
+ * Validate same-document fragment links and correct the case of heading links.
  */
 export const rehypeValidateHeadingLinks: Plugin<[], Root> = () => {
 	return (tree, file) => {
@@ -15,6 +30,7 @@ export const rehypeValidateHeadingLinks: Plugin<[], Root> = () => {
 
 		const headings = file.data.headingsWithIds;
 		const headingSlugsMap = new Map<string, string>();
+		const fragmentIds = new Set<string>();
 		for (const { slug } of headings) {
 			const lowerSlug = slug.toLowerCase();
 			const existingSlug = headingSlugsMap.get(lowerSlug);
@@ -31,12 +47,33 @@ export const rehypeValidateHeadingLinks: Plugin<[], Root> = () => {
 			headingSlugsMap.set(lowerSlug, slug);
 		}
 
+		visit(tree, (node) => {
+			if (node.type === "element") {
+				const id = (node as Element).properties["id"];
+				if (typeof id === "string") fragmentIds.add(id);
+			}
+
+			const componentFragmentIds = (node as NodeWithFragmentIds).fragmentIds;
+			if (!Array.isArray(componentFragmentIds)) return;
+
+			for (const id of componentFragmentIds) {
+				if (typeof id === "string") fragmentIds.add(id);
+			}
+		});
+
 		visit(tree, { type: "element", tagName: "a" }, (node) => {
 			const href = node.properties["href"];
 			if (typeof href !== "string" || !href.startsWith("#")) return;
 
-			const targetHeadingSlug = href.slice(1);
-			const headingSlug = headingSlugsMap.get(targetHeadingSlug.toLowerCase());
+			const candidates = fragmentCandidates(href.slice(1));
+			if (candidates.some((candidate) => fragmentIds.has(candidate))) return;
+
+			const targetHeadingSlug = candidates.find((candidate) =>
+				headingSlugsMap.has(candidate.toLowerCase()),
+			);
+			const headingSlug = targetHeadingSlug
+				? headingSlugsMap.get(targetHeadingSlug.toLowerCase())
+				: undefined;
 			if (!headingSlug) {
 				logError(
 					file,


### PR DESCRIPTION
This PR should fix the issues reported in our logs with:

```
web-1  | [ERROR] [rehypeValidateHeadingLinks] Unknown anchor link to heading "#user-content-fn-coolfootnote" in "/work/content/fennifith/posts/example/index.md".
web-1  | [ERROR] [rehypeValidateHeadingLinks] Unknown anchor link to heading "#user-content-fn-1" in "/work/content/fennifith/posts/example/index.md".
web-1  | [ERROR] [rehypeValidateHeadingLinks] Unknown anchor link to heading "#user-content-fn-2" in "/work/content/fennifith/posts/example/index.md".
web-1  | [ERROR] [rehypeValidateHeadingLinks] Unknown anchor link to heading "#welcome🦀🦀🦀" in "/work/content/fennifith/posts/example/index.md".
web-1  | [ERROR] [rehypeValidateHeadingLinks] Unknown anchor link to heading "#cool-id🦦🦦🦦" in "/work/content/fennifith/posts/example/index.md".
web-1  | [ERROR] [rehypeValidateHeadingLinks] Unknown anchor link to heading "#why-does-js" in "/work/content/fennifith/posts/example/index.md".
web-1  |
web-1  | 	<a href="#cool-id🦦🦦🦦" id="welcome🦀🦀🦀">Go back</a>
web-1  | 	^
web-1  | 	in /work/content/fennifith/posts/example/index.md:457
web-1  |
web-1  | 	[link](#why-does-js)
web-1  | 	^
web-1  | 	in /work/content/fennifith/posts/example/index.md:475
web-1  |
web-1  | 	in /work/content/fennifith/posts/example/index.md:undefined
web-1  |
web-1  | 	in /work/content/fennifith/posts/example/index.md:undefined
web-1  |
web-1  | 	in /work/content/fennifith/posts/example/index.md:undefined
```

And similar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of links targeting headings, quiz titles, components, and footnotes.
  * Added support for URI-encoded fragment links and corrected heading fragment matching.
  * Prevented valid component anchor links from being reported as broken.

* **Accessibility**
  * Quiz radio titles can now be targeted by links and accessibility references.

* **Tests**
  * Added coverage for valid, malformed, missing, and URI-encoded fragment links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->