### PR TITLE
Reintroduce Plausible Redirect Proxy

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -79,19 +79,26 @@ server {
         add_header Cache-Control "public, max-age=31536000, immutable";
     }
 
-	# Needed for Plausible Analytics
-    resolver 9.9.9.9; # Use quad9 DNS resolver. Remove this line if you've already configured a DNS resolver.
+	# Resolve Plausible through Fly's in-machine DNS. Public DNS can be
+	# unreachable from review machines and otherwise holds the request open for
+	# nginx's 30-second default resolver timeout.
+    resolver [fdaa::3] valid=300s;
+    resolver_timeout 5s;
     set $plausible_script_url https://plausible.io/js/script.outbound-links.local.js;
     set $plausible_event_url https://plausible.io/api/event;
 
  	location = /areyoumyuser/js/script.js {
         proxy_pass $plausible_script_url;
         proxy_set_header Host plausible.io;
+        proxy_ssl_server_name on;
+        proxy_ssl_name plausible.io;
     }
 
     location = /areyoumyuser/api/event {
         proxy_pass $plausible_event_url;
         proxy_set_header Host plausible.io;
+        proxy_ssl_server_name on;
+        proxy_ssl_name plausible.io;
         proxy_buffering on;
         proxy_http_version 1.1;
 


### PR DESCRIPTION
Quad9 may have banned us? Unclear, but this no longer works. Fix uses Fly's DNS: https://fly.io/docs/networking/private-networking/#connect-a-fly-machine-to-the-fly-io-dns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Plausible analytics proxy reliability by using Fly’s internal IPv6 DNS resolver with a 5-second timeout.
  - Enabled TLS server-name indication and explicit upstream TLS naming for Plausible connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->