### PR TITLE
Upgrade Playwright

### DIFF
--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7-labs
 
 # e2e: contains the Playwright test runner
-FROM mcr.microsoft.com/playwright:v1.60.0-jammy AS e2e
+FROM mcr.microsoft.com/playwright:v1.62.1-jammy AS e2e
 
 WORKDIR /work
 

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7-labs
 
 # e2e: contains the Playwright test runner
-FROM mcr.microsoft.com/playwright:v1.62.1-jammy AS e2e
+FROM mcr.microsoft.com/playwright:v1.62.1-resolute AS e2e
 
 WORKDIR /work
 

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -11,7 +11,7 @@
 		"test:interactive": "playwright test --config ./playwright.config.ts --ui"
 	},
 	"devDependencies": {
-		"@playwright/test": "1.60.0",
+		"@playwright/test": "1.62.1",
 		"cross-env": "^10.1.0"
 	},
 	"dependencies": {

--- a/e2e/tests/posts-example.spec.ts-snapshots/posts-example-renders-dark-mode-1-webkit-linux.png
+++ b/e2e/tests/posts-example.spec.ts-snapshots/posts-example-renders-dark-mode-1-webkit-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:21418aad14a13ee98802462d92419315359f63ae40dcad2d852bcd3f11fd87d7
-size 3781121
+oid sha256:be3c533b331ae08e4eb1404fa0111a6c0bb2c287de4154378a6435118ea8fb07
+size 3777160

--- a/e2e/tests/posts-example.spec.ts-snapshots/posts-example-renders-light-mode-1-webkit-linux.png
+++ b/e2e/tests/posts-example.spec.ts-snapshots/posts-example-renders-light-mode-1-webkit-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2fcdfc2745e68f88b4e00c3fa5ca955069a8df427626213131eb24270fb29d57
-size 3741303
+oid sha256:18b108388bf02b5a73052d8187b9b6fc81b0900dcc0b935cbf35eb36e8c93928
+size 3737251

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
 		"msw": "^2.14.6",
 		"octokit": "^5.0.5",
 		"openapi-typescript": "^7.13.0",
-		"playwright": "1.60.0",
+		"playwright": "1.62.1",
 		"postcss-html": "^2.0.0",
 		"postcss-scss": "^4.0.9",
 		"prettier": "^3.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@playwright/test': 1.60.0
-  playwright: 1.60.0
-  playwright-core: 1.60.0
+  '@playwright/test': 1.62.1
+  playwright: 1.62.1
+  playwright-core: 1.62.1
   react: npm:@preact/compat@18.3.1
   react-dom: npm:@preact/compat@18.3.1
 
@@ -156,7 +156,7 @@ importers:
         version: 3.0.3
       '@vitest/browser-playwright':
         specifier: ^4.1.7
-        version: 4.1.9(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(playwright@1.60.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.9)
+        version: 4.1.9(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(playwright@1.62.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.9)
       astro:
         specifier: ^7.0.0
         version: 7.0.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@25.9.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0)
@@ -251,8 +251,8 @@ importers:
         specifier: ^7.13.0
         version: 7.13.0(typescript@6.0.3)
       playwright:
-        specifier: 1.60.0
-        version: 1.60.0
+        specifier: 1.62.1
+        version: 1.62.1
       postcss-html:
         specifier: ^2.0.0
         version: 2.0.0(postcss@8.5.26)
@@ -372,8 +372,8 @@ importers:
         version: 5.8.5
     devDependencies:
       '@playwright/test':
-        specifier: 1.60.0
-        version: 1.60.0
+        specifier: 1.62.1
+        version: 1.62.1
       cross-env:
         specifier: ^10.1.0
         version: 10.1.0
@@ -1932,9 +1932,9 @@ packages:
   '@plausible-analytics/tracker@0.4.5':
     resolution: {integrity: sha512-6BfAGejXY+YA3Cw6LYT2Zpn4hTxDtPQAawFsYUsQCOg78wIS5C4deAGXTfJffa5VleMWITv5lpJ/EYuQBl1tPA==}
 
-  '@playwright/test@1.60.0':
-    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
-    engines: {node: '>=18'}
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
     hasBin: true
 
   '@polka/url@1.0.0-next.29':
@@ -2555,7 +2555,7 @@ packages:
   '@vitest/browser-playwright@4.1.9':
     resolution: {integrity: sha512-Bq1rOGf9waevzG3EOkO/dene6bvKTUsZMVg8S1i+WH3JcMjuXEjiahP9rAqZRELUqjBySOJsvvSWqK/B3wjKQw==}
     peerDependencies:
-      playwright: 1.60.0
+      playwright: 1.62.1
       vitest: 4.1.9
 
   '@vitest/browser@4.1.9':
@@ -5670,14 +5670,14 @@ packages:
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
 
-  playwright-core@1.60.0:
-    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
-    engines: {node: '>=18'}
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
     hasBin: true
 
-  playwright@1.60.0:
-    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
-    engines: {node: '>=18'}
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
     hasBin: true
 
   pluralize@8.0.0:
@@ -8632,9 +8632,9 @@ snapshots:
 
   '@plausible-analytics/tracker@0.4.5': {}
 
-  '@playwright/test@1.60.0':
+  '@playwright/test@1.62.1':
     dependencies:
-      playwright: 1.60.0
+      playwright: 1.62.1
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -9264,11 +9264,11 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  '@vitest/browser-playwright@4.1.9(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(playwright@1.60.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.9)':
+  '@vitest/browser-playwright@4.1.9(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(playwright@1.62.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.9)':
     dependencies:
       '@vitest/browser': 4.1.9(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.9)
       '@vitest/mocker': 4.1.9(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0))
-      playwright: 1.60.0
+      playwright: 1.62.1
       tinyrainbow: 3.1.0
       vitest: 4.1.9(@types/node@25.9.1)(@vitest/browser-playwright@4.1.9)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0))
     transitivePeerDependencies:
@@ -13116,11 +13116,11 @@ snapshots:
       exsolve: 1.0.8
       pathe: 2.0.3
 
-  playwright-core@1.60.0: {}
+  playwright-core@1.62.1: {}
 
-  playwright@1.60.0:
+  playwright@1.62.1:
     dependencies:
-      playwright-core: 1.60.0
+      playwright-core: 1.62.1
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -14597,7 +14597,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.1
-      '@vitest/browser-playwright': 4.1.9(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(playwright@1.60.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/browser-playwright': 4.1.9(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(playwright@1.62.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.9)
     transitivePeerDependencies:
       - msw
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,9 +4,9 @@ packages:
   - .
 minimumReleaseAge: 10080
 overrides:
-  "@playwright/test": 1.60.0
-  playwright: 1.60.0
-  playwright-core: 1.60.0
+  "@playwright/test": 1.62.1
+  playwright: 1.62.1
+  playwright-core: 1.62.1
   react: "npm:@preact/compat@18.3.1"
   react-dom: "npm:@preact/compat@18.3.1"
 allowBuilds:


### PR DESCRIPTION
Fixes failures in #1676 due to Playwright 1.60.0 not supporting Ubuntu 26.04

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Playwright testing tools and end-to-end test environment to version 1.62.1.
  * Aligned Playwright package versions across the project for consistent test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->