### PR TITLE
Fix PFP component usage in normal html

### DIFF
--- a/__mocks__/imports/astro-mock.ts
+++ b/__mocks__/imports/astro-mock.ts
@@ -1,0 +1,4 @@
+// Node tests exercise markdown transforms without rendering Astro components.
+export default function AstroComponent() {
+	return null;
+}

--- a/src/components/hint/hint.tsx
+++ b/src/components/hint/hint.tsx
@@ -10,14 +10,14 @@ interface HintProps {
 
 export function Hint({ title, children }: HintProps) {
 	return (
-		<div class={`${style.hint} markdownCollapsePadding`}>
-			<details class={style.details}>
-				<summary class={`${style.title} text-style-body-medium-bold`}>
+		<div className={`${style.hint} markdownCollapsePadding`}>
+			<details className={style.details}>
+				<summary className={`${style.title} text-style-body-medium-bold`}>
 					<RawSvg aria-hidden icon={ChevronDownIcon} />
 					{title}
 				</summary>
 
-				<div class={style.content}>{children}</div>
+				<div className={style.content}>{children}</div>
 			</details>
 		</div>
 	);

--- a/src/utils/markdown/components/hint/rehype-transform.node.spec.ts
+++ b/src/utils/markdown/components/hint/rehype-transform.node.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import type { Element } from "hast";
 import { fromHtml } from "hast-util-from-html";
 import { toHtml } from "hast-util-to-html";
@@ -19,24 +19,6 @@ import { rehypeValidateComponents } from "../rehype-validate-components.ts";
 import { rehypeTransformComponents } from "../rehype-transform-components.ts";
 import { rehypePluginComponents } from "../rehype-plugin-components.ts";
 import { rehypeDetailsElement, transformDetails } from "./rehype-transform.ts";
-
-vi.mock("../components.ts", () => ({
-	createComponent: (
-		component: string,
-		props: object,
-		children: ComponentNode["children"] = [],
-	) => ({
-		type: "playful-component",
-		component,
-		props,
-		children,
-	}),
-	isComponentMarkup: (node: { type?: string }) =>
-		node?.type === "playful-component-markup",
-	isComponentNode: (node: { type?: string }) =>
-		node?.type === "playful-component",
-	isHtmlNode: (node: { type?: string }) => node?.type === "html",
-}));
 
 async function processMarkdown(value: string, wrapInComponent = false) {
 	const processor = unified()

--- a/src/utils/markdown/components/hint/rehype-transform.node.spec.ts
+++ b/src/utils/markdown/components/hint/rehype-transform.node.spec.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Element } from "hast";
+import { fromHtml } from "hast-util-from-html";
+import { toHtml } from "hast-util-to-html";
+import { toString } from "hast-util-to-string";
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkToRehype from "remark-rehype";
+import rehypeRaw from "rehype-raw";
+import {
+	type ComponentNode,
+	type PlayfulNode,
+	type PlayfulRoot,
+	createComponent,
+	isComponentNode,
+	isHtmlNode,
+} from "../components.ts";
+import { rehypeValidateComponents } from "../rehype-validate-components.ts";
+import { rehypeTransformComponents } from "../rehype-transform-components.ts";
+import { rehypePluginComponents } from "../rehype-plugin-components.ts";
+import { rehypeDetailsElement, transformDetails } from "./rehype-transform.ts";
+
+vi.mock("../components.ts", () => ({
+	createComponent: (
+		component: string,
+		props: object,
+		children: ComponentNode["children"] = [],
+	) => ({
+		type: "playful-component",
+		component,
+		props,
+		children,
+	}),
+	isComponentMarkup: (node: { type?: string }) =>
+		node?.type === "playful-component-markup",
+	isComponentNode: (node: { type?: string }) =>
+		node?.type === "playful-component",
+	isHtmlNode: (node: { type?: string }) => node?.type === "html",
+}));
+
+async function processMarkdown(value: string, wrapInComponent = false) {
+	const processor = unified()
+		.use(remarkParse)
+		.use(remarkToRehype, { allowDangerousHtml: true })
+		.use(rehypeRaw)
+		.use(() => (tree: PlayfulRoot) => {
+			if (wrapInComponent) {
+				tree.children = [
+					createComponent(
+						"Tooltip",
+						{ title: "Wrapper", icon: "info" },
+						tree.children,
+					),
+				];
+			}
+		})
+		.use(rehypeDetailsElement)
+		.use(rehypeValidateComponents)
+		.use(rehypeTransformComponents, {
+			components: { hint: transformDetails },
+		})
+		.use(rehypePluginComponents, {
+			htmlOptions: { allowDangerousHtml: true, voids: [] },
+		});
+	const file = await processor.process({ value, path: "details-test.md" });
+
+	return file.result as PlayfulNode[];
+}
+
+// Stand in for Content.astro: HTML chunks and component output must concatenate
+// into valid markup without losing the elements surrounding each component.
+function renderComponents(nodes: ComponentNode["children"]): string {
+	return nodes
+		.map((node) => {
+			if (isHtmlNode(node)) return node.innerHtml;
+			if (node.type === "root") return renderComponents(node.children);
+			if (isComponentNode(node)) {
+				return toHtml(
+					{
+						type: "element",
+						tagName: node.component.toLowerCase(),
+						properties: {
+							title: (node.props as { title: string }).title,
+						},
+						children: [{ type: "raw", value: renderComponents(node.children) }],
+					},
+					{ allowDangerousHtml: true },
+				);
+			}
+			throw new Error(`Uncompiled node: ${node.type}`);
+		})
+		.join("");
+}
+
+function getComponents(nodes: ComponentNode["children"]): ComponentNode[] {
+	return nodes.flatMap((node) => {
+		if (isComponentNode(node)) return [node, ...getComponents(node.children)];
+		if (node.type === "root") return getComponents(node.children);
+		return [];
+	});
+}
+
+describe("Details markdown component", () => {
+	it.each([
+		{ tagName: "ul", markers: ["-", "-", "-"] },
+		{ tagName: "ol", markers: ["1.", "2.", "3."] },
+	])(
+		"transforms details inside a $tagName list item",
+		async ({ tagName, markers }) => {
+			const indent = " ".repeat(markers[1].length + 1);
+			const source = [
+				`${markers[0]} List item 1`,
+				"",
+				`${markers[1]} List item 2`,
+				`${indent}<details>`,
+				`${indent}  <summary>What's this?</summary>`,
+				`${indent}  OwO`,
+				`${indent}</details>`,
+				"",
+				`${markers[2]} List item 3`,
+			].join("\n");
+
+			const nodes = await processMarkdown(source);
+			expect(getComponents(nodes)).toMatchObject([
+				{ component: "Hint", props: { title: "What's this?" } },
+			]);
+
+			const html = renderComponents(nodes);
+			const root = fromHtml(html, { fragment: true });
+			const list = root.children.find(
+				(node): node is Element =>
+					node.type === "element" && node.tagName === tagName,
+			);
+			expect(list).toBeDefined();
+			const items = list!.children.filter(
+				(node): node is Element =>
+					node.type === "element" && node.tagName === "li",
+			);
+			expect(
+				items.map((node) => toString(node).replace(/\s+/g, " ").trim()),
+			).toEqual(["List item 1", "List item 2 OwO", "List item 3"]);
+			expect(
+				items[1].children.filter((node) => node.type === "element"),
+			).toMatchObject([
+				{ tagName: "p" },
+				{ tagName: "hint", properties: { title: "What's this?" } },
+			]);
+			expect(html).not.toContain("<details");
+		},
+	);
+
+	it("preserves HTML siblings immediately before and after a component", async () => {
+		const nodes = await processMarkdown(
+			'<div class="wrapper" data-label="A &amp; B"><p>Before</p><details><summary>Title</summary>Body</details>tail<strong>After</strong></div>',
+		);
+
+		expect(renderComponents(nodes)).toBe(
+			'<div class="wrapper" data-label="A &#x26; B"><p>Before</p><hint title="Title">Body</hint>tail<strong>After</strong></div>',
+		);
+	});
+
+	it("preserves a top-level element immediately before a component", async () => {
+		const nodes = await processMarkdown(
+			"<p>Before</p><details><summary>Title</summary>Body</details><p>After</p>",
+		);
+
+		expect(renderComponents(nodes)).toBe(
+			'<p>Before</p><hint title="Title">Body</hint><p>After</p>',
+		);
+	});
+
+	it("transforms details nested directly inside details", async () => {
+		const nodes = await processMarkdown(
+			"<details><summary>Outer</summary>Before<details><summary>Inner</summary>Inside</details>After</details>",
+		);
+
+		expect(getComponents(nodes).map((node) => node.props)).toEqual([
+			{ title: "Outer" },
+			{ title: "Inner" },
+		]);
+		expect(renderComponents(nodes)).toBe(
+			'<hint title="Outer">Before<hint title="Inner">Inside</hint>After</hint>',
+		);
+	});
+
+	it("leaves details without a direct summary while transforming its nested details", async () => {
+		const nodes = await processMarkdown(
+			"<details>Before<details><summary>Inner</summary>Inside</details>After</details>",
+		);
+
+		expect(getComponents(nodes)).toMatchObject([
+			{ component: "Hint", props: { title: "Inner" } },
+		]);
+		expect(renderComponents(nodes)).toBe(
+			'<details>Before<hint title="Inner">Inside</hint>After</details>',
+		);
+	});
+
+	it("transforms details beneath an already-created component", async () => {
+		const nodes = await processMarkdown(
+			"<div>Before<details><summary>Inner</summary>Inside</details>After</div>",
+			true,
+		);
+
+		expect(getComponents(nodes).map((node) => node.component)).toEqual([
+			"Tooltip",
+			"Hint",
+		]);
+		expect(renderComponents(nodes)).toBe(
+			'<tooltip title="Wrapper"><div>Before<hint title="Inner">Inside</hint>After</div></tooltip>',
+		);
+	});
+});

--- a/src/utils/markdown/components/hint/rehype-transform.node.spec.ts
+++ b/src/utils/markdown/components/hint/rehype-transform.node.spec.ts
@@ -83,53 +83,87 @@ function getComponents(nodes: ComponentNode["children"]): ComponentNode[] {
 }
 
 describe("Details markdown component", () => {
-	it.each([
-		{ tagName: "ul", markers: ["-", "-", "-"] },
-		{ tagName: "ol", markers: ["1.", "2.", "3."] },
-	])(
-		"transforms details inside a $tagName list item",
-		async ({ tagName, markers }) => {
-			const indent = " ".repeat(markers[1].length + 1);
-			const source = [
-				`${markers[0]} List item 1`,
-				"",
-				`${markers[1]} List item 2`,
-				`${indent}<details>`,
-				`${indent}  <summary>What's this?</summary>`,
-				`${indent}  OwO`,
-				`${indent}</details>`,
-				"",
-				`${markers[2]} List item 3`,
-			].join("\n");
+	it("transforms details inside an unordered list item", async () => {
+		const source = [
+			"- List item 1",
+			"",
+			"- List item 2",
+			"  <details>",
+			"    <summary>What's this?</summary>",
+			"    OwO",
+			"  </details>",
+			"",
+			"- List item 3",
+		].join("\n");
 
-			const nodes = await processMarkdown(source);
-			expect(getComponents(nodes)).toMatchObject([
-				{ component: "Hint", props: { title: "What's this?" } },
-			]);
+		const nodes = await processMarkdown(source);
+		expect(getComponents(nodes)).toMatchObject([
+			{ component: "Hint", props: { title: "What's this?" } },
+		]);
 
-			const html = renderComponents(nodes);
-			const root = fromHtml(html, { fragment: true });
-			const list = root.children.find(
-				(node): node is Element =>
-					node.type === "element" && node.tagName === tagName,
-			);
-			expect(list).toBeDefined();
-			const items = list!.children.filter(
-				(node): node is Element =>
-					node.type === "element" && node.tagName === "li",
-			);
-			expect(
-				items.map((node) => toString(node).replace(/\s+/g, " ").trim()),
-			).toEqual(["List item 1", "List item 2 OwO", "List item 3"]);
-			expect(
-				items[1].children.filter((node) => node.type === "element"),
-			).toMatchObject([
-				{ tagName: "p" },
-				{ tagName: "hint", properties: { title: "What's this?" } },
-			]);
-			expect(html).not.toContain("<details");
-		},
-	);
+		const html = renderComponents(nodes);
+		const root = fromHtml(html, { fragment: true });
+		const list = root.children.find(
+			(node): node is Element =>
+				node.type === "element" && node.tagName === "ul",
+		);
+		expect(list).toBeDefined();
+		const items = list!.children.filter(
+			(node): node is Element =>
+				node.type === "element" && node.tagName === "li",
+		);
+		expect(
+			items.map((node) => toString(node).replace(/\s+/g, " ").trim()),
+		).toEqual(["List item 1", "List item 2 OwO", "List item 3"]);
+		expect(
+			items[1].children.filter((node) => node.type === "element"),
+		).toMatchObject([
+			{ tagName: "p" },
+			{ tagName: "hint", properties: { title: "What's this?" } },
+		]);
+		expect(html).not.toContain("<details");
+	});
+
+	it("transforms details inside an ordered list item", async () => {
+		const source = [
+			"1. List item 1",
+			"",
+			"2. List item 2",
+			"   <details>",
+			"     <summary>What's this?</summary>",
+			"     OwO",
+			"   </details>",
+			"",
+			"3. List item 3",
+		].join("\n");
+
+		const nodes = await processMarkdown(source);
+		expect(getComponents(nodes)).toMatchObject([
+			{ component: "Hint", props: { title: "What's this?" } },
+		]);
+
+		const html = renderComponents(nodes);
+		const root = fromHtml(html, { fragment: true });
+		const list = root.children.find(
+			(node): node is Element =>
+				node.type === "element" && node.tagName === "ol",
+		);
+		expect(list).toBeDefined();
+		const items = list!.children.filter(
+			(node): node is Element =>
+				node.type === "element" && node.tagName === "li",
+		);
+		expect(
+			items.map((node) => toString(node).replace(/\s+/g, " ").trim()),
+		).toEqual(["List item 1", "List item 2 OwO", "List item 3"]);
+		expect(
+			items[1].children.filter((node) => node.type === "element"),
+		).toMatchObject([
+			{ tagName: "p" },
+			{ tagName: "hint", properties: { title: "What's this?" } },
+		]);
+		expect(html).not.toContain("<details");
+	});
 
 	it("preserves HTML siblings immediately before and after a component", async () => {
 		const nodes = await processMarkdown(

--- a/src/utils/markdown/components/hint/rehype-transform.ts
+++ b/src/utils/markdown/components/hint/rehype-transform.ts
@@ -1,6 +1,4 @@
-import type * as hast from "hast";
 import type { Plugin } from "unified";
-import { find } from "unist-util-find";
 import { visit } from "unist-util-visit";
 import { toString } from "hast-util-to-string";
 import type { RehypeFunctionComponent } from "../types.ts";
@@ -10,6 +8,7 @@ import {
 	createComponent,
 } from "../components.ts";
 import { isValidComponentParent } from "../rehype-validate-components.ts";
+import { isElement } from "../../unist-is-element.ts";
 
 export const rehypeDetailsElement: Plugin<[], PlayfulRoot> = () => {
 	return (tree, _) => {
@@ -18,13 +17,16 @@ export const rehypeDetailsElement: Plugin<[], PlayfulRoot> = () => {
 			{ type: "element", tagName: "details" },
 			(node, index, parent) => {
 				if (typeof index === "undefined") return;
-				if (!isValidComponentParent(parent)) return;
+				if (!isValidComponentParent(parent) && !isElement(parent)) return;
 
-				const summary = find<hast.Element>(node, {
-					type: "element",
-					tagName: "summary",
-				});
+				const summary = node.children.find(
+					(child) => isElement(child) && child.tagName === "summary",
+				);
 				if (!summary) return;
+
+				// visit continues through the original node after replacement. Keep
+				// its children array so nested details replacements are retained.
+				node.children.splice(node.children.indexOf(summary), 1);
 
 				const replacement: ComponentMarkupNode = {
 					type: "playful-component-markup",
@@ -33,10 +35,11 @@ export const rehypeDetailsElement: Plugin<[], PlayfulRoot> = () => {
 					attributes: {
 						title: toString(summary),
 					},
-					children: node.children.filter((child) => child !== summary),
+					children: node.children,
 				};
 
-				parent.children.splice(index, 1, replacement);
+				const siblings: PlayfulRoot["children"] = parent.children;
+				siblings.splice(index, 1, replacement);
 			},
 		);
 	};

--- a/src/utils/markdown/components/mermaid/rehype-transform.node.spec.ts
+++ b/src/utils/markdown/components/mermaid/rehype-transform.node.spec.ts
@@ -18,19 +18,6 @@ vi.mock("../../shiki/shiki-pool.ts", () => ({
 	runShiki: vi.fn(async (node: Element) => node),
 }));
 
-vi.mock("../components.ts", () => ({
-	createComponent: (component: string, props: object) => ({
-		type: "playful-component",
-		component,
-		props,
-		children: [],
-	}),
-	isComponentMarkup: (node: { type?: string }) =>
-		node?.type === "playful-component-markup",
-	isComponentNode: (node: { type?: string }) =>
-		node?.type === "playful-component",
-}));
-
 const fileInfo = {
 	kind: "post" as const,
 	file: "mermaid-test.md",

--- a/src/utils/markdown/components/rehype-plugin-components.ts
+++ b/src/utils/markdown/components/rehype-plugin-components.ts
@@ -7,71 +7,83 @@ import {
 	isHtmlNode,
 } from "./components.ts";
 import { type Options as HtmlOptions, toHtml } from "hast-util-to-html";
-import { isRoot } from "../unist-is-element.ts";
+import { isElement, isRoot } from "../unist-is-element.ts";
 
 interface ComponentsOptions {
 	htmlOptions: HtmlOptions;
+}
+
+function containsPlayfulNode(node: PlayfulRoot["children"][number]): boolean {
+	return (
+		isComponentNode(node) ||
+		isHtmlNode(node) ||
+		isRoot(node) ||
+		(isElement(node) && node.children.some(containsPlayfulNode))
+	);
 }
 
 export function compileToPlayfulNodes(
 	tree: PlayfulRoot,
 	options: ComponentsOptions,
 ): PlayfulNode[] {
-	const results: Array<{
-		index: number;
-		node: PlayfulNode;
-	}> = [];
+	const nodes: PlayfulNode[] = [];
+	let pendingHtml: hast.ElementContent[] = [];
+	function flushHtml() {
+		if (!pendingHtml.length) return;
+		nodes.push({
+			type: "html",
+			innerHtml: toHtml(pendingHtml, options.htmlOptions),
+		});
+		pendingHtml = [];
+	}
 
-	for (let index = 0; index < tree.children.length; index++) {
-		const node = tree.children[index];
-
+	for (const node of tree.children) {
 		if (isComponentNode(node)) {
-			const compiledNode = {
+			flushHtml();
+			nodes.push({
 				...node,
 				children: compileToPlayfulNodes(
 					{ type: "root", children: node.children ?? [] },
 					options,
 				),
-			};
-			results.push({ index, node: compiledNode });
+			});
 		} else if (isHtmlNode(node)) {
-			results.push({ index, node });
+			flushHtml();
+			nodes.push(node);
 		} else if (isRoot(node)) {
+			flushHtml();
 			const children = compileToPlayfulNodes(node, options);
-			results.push({ index, node: { type: "root", children } });
-		}
-	}
-
-	const nodes: PlayfulNode[] = [];
-	for (const [result, index] of results.map((r, i) => [r, i] as const)) {
-		const preStart = (results[index - 1]?.index ?? -1) + 1;
-		const preEnd = result.index - 1;
-		if (preEnd - preStart > 0) {
-			const innerHtml = toHtml(
-				tree.children.slice(preStart, preEnd) as hast.ElementContent[],
-				options.htmlOptions,
+			nodes.push({ type: "root", children });
+		} else if (isElement(node) && containsPlayfulNode(node)) {
+			flushHtml();
+			// Keep enclosing HTML around components without passing custom nodes
+			// to toHtml. Force an explicit closing tag to split the empty shell.
+			const closingTag = `</${node.tagName}>`;
+			const shell = toHtml(
+				{ ...node, children: [] },
+				{
+					...options.htmlOptions,
+					omitOptionalTags: false,
+					closeEmptyElements: false,
+					voids: [],
+				},
 			);
 			nodes.push({
 				type: "html",
-				innerHtml,
+				innerHtml: shell.slice(0, -closingTag.length),
 			});
+			nodes.push(
+				...compileToPlayfulNodes(
+					{ type: "root", children: node.children },
+					options,
+				),
+			);
+			nodes.push({ type: "html", innerHtml: closingTag });
+		} else {
+			pendingHtml.push(node as hast.ElementContent);
 		}
-
-		nodes.push(result.node);
 	}
-
-	if ((results.at(-1)?.index ?? -1) + 1 < tree.children.length) {
-		const postStart = (results.at(-1)?.index ?? -1) + 1;
-		const postEnd = tree.children.length;
-		const innerHtml = toHtml(
-			tree.children.slice(postStart, postEnd) as hast.ElementContent[],
-			options.htmlOptions,
-		);
-		nodes.push({
-			type: "html",
-			innerHtml,
-		});
-	}
+	flushHtml();
 
 	return nodes;
 }

--- a/src/utils/markdown/components/rehype-transform-components.ts
+++ b/src/utils/markdown/components/rehype-transform-components.ts
@@ -6,7 +6,6 @@ import {
 	type PlayfulNode,
 	type PlayfulRoot,
 	isComponentMarkup,
-	isComponentNode,
 } from "./components.ts";
 
 type RehypeComponentsProps = {
@@ -27,9 +26,13 @@ export const rehypeTransformComponents: Plugin<
 		for (let index = 0; index < tree.children.length; index++) {
 			const node = tree.children[index];
 
-			if (isComponentNode(node)) {
-				results.push({ index, node, replacement: [node] });
-				continue;
+			// Components can also live inside ordinary HTML or a component
+			// produced by an earlier plugin. Always transform children first.
+			if ("children" in node) {
+				await transformComponents(
+					{ type: "root", children: node.children },
+					vfile,
+				);
 			}
 
 			if (!isComponentMarkup(node)) continue;
@@ -40,12 +43,6 @@ export const rehypeTransformComponents: Plugin<
 				logError(vfile, node, `Unknown markdown component ${node.component}`);
 				throw new Error();
 			}
-
-			// Transform the child components first!
-			await transformComponents(
-				{ type: "root", children: node.children },
-				vfile,
-			);
 
 			const replacement = component({
 				vfile,

--- a/src/utils/markdown/components/rehype-validate-components.ts
+++ b/src/utils/markdown/components/rehype-validate-components.ts
@@ -7,7 +7,7 @@ import {
 	isComponentMarkup,
 	isComponentNode,
 } from "./components.ts";
-import { isRoot } from "../unist-is-element.ts";
+import { isElement, isRoot } from "../unist-is-element.ts";
 
 export function isValidComponentParent(node: hast.Node | undefined) {
 	return isRoot(node) || isComponentNode(node) || isComponentMarkup(node);
@@ -16,7 +16,7 @@ export function isValidComponentParent(node: hast.Node | undefined) {
 export const rehypeValidateComponents: Plugin<[], PlayfulRoot> = () => {
 	return (tree, vfile) => {
 		visit(tree, isComponentMarkup, (node, _, parent) => {
-			if (!isValidComponentParent(parent)) {
+			if (!isValidComponentParent(parent) && !isElement(parent)) {
 				logError(
 					vfile,
 					node,
@@ -27,7 +27,7 @@ export const rehypeValidateComponents: Plugin<[], PlayfulRoot> = () => {
 		});
 
 		visit(tree, isComponentNode, (node, _, parent) => {
-			if (!isValidComponentParent(parent)) {
+			if (!isValidComponentParent(parent) && !isElement(parent)) {
 				logError(
 					vfile,
 					node,

--- a/vitest.config.node.ts
+++ b/vitest.config.node.ts
@@ -1,6 +1,17 @@
 import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
 
 export default defineConfig({
+	resolve: {
+		alias: [
+			{
+				find: /^.*\.astro$/,
+				replacement: fileURLToPath(
+					new URL("./__mocks__/imports/astro-mock.ts", import.meta.url),
+				),
+			},
+		],
+	},
 	test: {
 		name: "node",
 		include: ["**/*.node.spec.ts"],


### PR DESCRIPTION
This PR fixes PFP Component usage in non-PFP Markdown component usage (IE: lists, others)

# Before

<img width="243" height="170" alt="image" src="https://github.com/user-attachments/assets/54713e89-ee19-4fe6-84f7-6bbf37fbf841" />

# After

<img width="257" height="148" alt="image" src="https://github.com/user-attachments/assets/ebafa354-afe9-4744-a3bb-869a3e71a285" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Markdown component rendering within lists, nested content, and surrounding HTML.
  - Preserved nested interactive details and hint content during Markdown transformation.
  - Improved handling of details blocks without a direct summary.
  - Enabled components to render correctly inside standard HTML elements.

- **Tests**
  - Expanded coverage for nested hints, list placement, sibling HTML, and component interactions.
  - Improved test reliability for Astro-based rendering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->