### PR TITLE
perf(shiki): load grammars on demand in worker threads

### DIFF
--- a/content/LayZee/posts/a-look-at-major-features-in-the-angular-ivy-version-9-release-4dn7/index.md
+++ b/content/LayZee/posts/a-look-at-major-features-in-the-angular-ivy-version-9-release-4dn7/index.md
@@ -168,7 +168,7 @@ Templates are type checked, according to the template type checking mode as desc
 
 The `ng new` workspace schematic now supports the `--strict` flag which defaults to off (`false`).
 
-```language-bash
+```bash
 ng new my-app --strict
 ```
 
@@ -279,7 +279,7 @@ As part of the Ivy styling rewrite, binding CSS Custom Properties is now support
 
 An example binding looks like this:
 
-```language-html
+```html
 <div [style.--my-var]="myProperty || 'any value'"></div>
 ```
 

--- a/content/crutchcorn/posts/change-host-file-android-emulator/index.md
+++ b/content/crutchcorn/posts/change-host-file-android-emulator/index.md
@@ -96,7 +96,7 @@ Inside the emulator, the IP address `10.0.2.2` refers to the *host* OS. For exam
 
 Knowing these two things, you can change the host file to make `example.com` refer to the host by adding the following to the host file:
 
-```plaintext
+```text
 10.0.2.2 example.com
 ```
 

--- a/content/danywalls/posts/testing-components-in-angular-no-errors-schema-stub-components-and-ngmocks-2bih/index.md
+++ b/content/danywalls/posts/testing-components-in-angular-no-errors-schema-stub-components-and-ngmocks-2bih/index.md
@@ -96,7 +96,7 @@ describe('ProductsComponent', () => {
 
 and... tada!!! 😭 I started to get weird errors:
 
-```plaintext
+```text
  NullInjectorError: R3InjectorError(DynamicTestModule)[ProductsService -> HttpClient -> HttpClient]:
 ```
 

--- a/content/domet99/posts/gemini-cli-googles-free-ai-agent-for-your-terminal/index.md
+++ b/content/domet99/posts/gemini-cli-googles-free-ai-agent-for-your-terminal/index.md
@@ -82,7 +82,7 @@ The agent reads your entire project context (up to 1M tokens with Gemini 2.5 Pro
 
 Example conversation:
 
-```plaintext
+```text
 You: Add user authentication to this Express app with JWT tokens
 Agent: [reads codebase, creates plan]
 Agent: I'll create:

--- a/content/gioboa/posts/azure-foundry-creating-a-pay-as-you-go-llm-service-207d/index.md
+++ b/content/gioboa/posts/azure-foundry-creating-a-pay-as-you-go-llm-service-207d/index.md
@@ -30,7 +30,7 @@ The key to a successful pay-as-you-go model is accurate tracking of LLM usage.
 
 By analysing the LLM's response, specifically the `usage` section of the response, you can determine the cost associated with each API call. So you can define your pricing based on these values.
 
-```JSON
+```json
 {
   [...]
   "usage": {

--- a/content/puppo/posts/its-prisma-time-migrations-7pk/index.md
+++ b/content/puppo/posts/its-prisma-time-migrations-7pk/index.md
@@ -76,7 +76,7 @@ model AuthorsOnPost {
 
 Once this is done, we can generate our first migration using this command
 
-```cli
+```bash
 npx prisma migrate dev
 ```
 
@@ -86,7 +86,7 @@ If you open this folder, you find a file called `migration.sql`, where you can s
 In this case, in this file, there are 3 CREATE TABLE commands, each for every entity (Author, Post, AuthorsOnPost).
 Prisma allows us to indicate migration's name too by using the `--name` option. Therefore the previous command could be executed in this way
 
-```cli
+```bash
 npx prisma migrate dev --name create_post_and_author_entities
 ```
 
@@ -131,7 +131,7 @@ model Author {
 
 Now it's time to create our second migration using the next command
 
-```cli
+```bash
 npx prisma migrate dev --name add_comment_entity
 ```
 
@@ -169,7 +169,7 @@ model Author {
 After that it's time to create our migration. This time though, we'll use a special option `--create-only`. This option allows us to create the migration script but this time the migration doesn't execute yet.
 Now execute the following command
 
-```cli
+```bash
 npx prisma migrate dev --name rename_author_columns --create-only
 ```
 
@@ -205,7 +205,7 @@ FROM "authors";
 
 Now it's time to do the last step to make this migration real
 
-```cli
+```bash
 npx prisma migrate dev
 ```
 

--- a/content/puppo/posts/its-prisma-time-seeding-43h4/index.md
+++ b/content/puppo/posts/its-prisma-time-seeding-43h4/index.md
@@ -67,7 +67,7 @@ The configuration is easy and we can instruct prisma in this way
 These three lines of code indicate to Prisma that we want to handle its seed command. When this command is executed the system uses the ts-node tool to build and execute the file `prisma/seed/index.ts`.
 But Prisma doesn't stop its work here. It executes this command after the migrate command too. Thus now we can execute this command
 
-```cli
+```bash
 npx prisma migrate dev
 ```
 
@@ -94,7 +94,7 @@ main();
 
 and after that run the command
 
-```cli
+```bash
 npm run dev
 ```
 

--- a/content/santoshyadavdev/posts/the-tree-shaking-journey-in-angular-a-deep-dive-52ie/index.md
+++ b/content/santoshyadavdev/posts/the-tree-shaking-journey-in-angular-a-deep-dive-52ie/index.md
@@ -18,7 +18,7 @@ Before we jump into the topic, let's understand tree shaking. The build tools we
 
 Let's take the code below, for example, where we have two methods, `add`  and `sub`.
 
-```Javascript
+```javascript
 export function add(a,b){
 	return a+b;
 }

--- a/src/utils/markdown/shiki/get-code-language.ts
+++ b/src/utils/markdown/shiki/get-code-language.ts
@@ -1,0 +1,15 @@
+import type { Element } from "hast";
+
+/** Returns the `language-*` suffix of a `<pre><code>` block, if any. */
+export function getCodeLanguage(node: Element): string | undefined {
+	const code = node.children.find(
+		(child): child is Element =>
+			child.type === "element" && child.tagName === "code",
+	);
+	const classNames = Array.isArray(code?.properties.className)
+		? code.properties.className.map(String)
+		: [];
+	return classNames
+		.find((className) => className.startsWith("language-"))
+		?.slice("language-".length);
+}

--- a/src/utils/markdown/shiki/rehype-transform.ts
+++ b/src/utils/markdown/shiki/rehype-transform.ts
@@ -1,23 +1,15 @@
+// walks files for code block languages and embedded languages to load syntax highlighting. skips handling mermaid for a future pipeline step
 import type { Element, Root } from "hast";
 import type { Plugin } from "unified";
 import { visit } from "unist-util-visit";
+import { bundledLanguages } from "shiki/langs";
+import { isSpecialLang } from "shiki/core";
 import { runShiki } from "./shiki-pool.ts";
-
-// Mermaid's component transform needs the original fenced-code AST and source.
-function isMermaidCodeBlock(node: Element): boolean {
-	const code = node.children.find(
-		(child): child is Element =>
-			child.type === "element" && child.tagName === "code",
-	);
-	const classNames = Array.isArray(code?.properties.className)
-		? code.properties.className.map(String)
-		: [];
-
-	return classNames.includes("language-mermaid");
-}
+import { getCodeLanguage } from "./get-code-language.ts";
+import { logError } from "../logger.ts";
 
 export const rehypeShikiUU: Plugin<[], Root, Root> = function () {
-	return async (tree) => {
+	return async (tree, file) => {
 		async function visitor(
 			node: Element,
 			index: number,
@@ -29,13 +21,19 @@ export const rehypeShikiUU: Plugin<[], Root, Root> = function () {
 
 		const promises: Array<Promise<void>> = [];
 		visit(tree, { type: "element", tagName: "pre" }, (node, index, parent) => {
-			if (
-				!isMermaidCodeBlock(node) &&
-				index !== undefined &&
-				parent !== undefined
-			) {
-				promises.push(visitor(node, index, parent));
+			if (index === undefined || parent === undefined) return;
+			const lang = getCodeLanguage(node);
+			// Mermaid's component transform needs the original fenced-code AST and source.
+			if (lang === "mermaid") return;
+			if (lang && !(lang in bundledLanguages) && !isSpecialLang(lang)) {
+				logError(
+					file,
+					node,
+					`Unrecognized code block language "${lang}"; highlights will not be applied`,
+				);
+				return;
 			}
+			promises.push(visitor(node, index, parent));
 		});
 		await Promise.all(promises);
 	};

--- a/src/utils/markdown/shiki/worker.ts
+++ b/src/utils/markdown/shiki/worker.ts
@@ -1,17 +1,29 @@
-import rehypeShiki, { type RehypeShikiOptions } from "@shikijs/rehype";
+import rehypeShikiFromHighlighter, {
+	type RehypeShikiCoreOptions,
+} from "@shikijs/rehype/core";
 import type { Root, Element } from "hast";
-import { type Transformer } from "unified";
+import { VFile } from "vfile";
 import {
 	transformerMetaHighlight,
 	transformerNotationHighlight,
 	transformerRemoveLineBreak,
 } from "@shikijs/transformers";
+import {
+	type DynamicImportLanguageRegistration,
+	type LanguageRegistration,
+	bundledLanguages,
+	createHighlighter,
+	isSpecialLang,
+} from "shiki";
+import { getCodeLanguage } from "./get-code-language.ts";
 
-const options: RehypeShikiOptions = {
-	themes: {
-		light: "github-light",
-		dark: "github-dark",
-	},
+const themes = {
+	light: "github-light",
+	dark: "github-dark",
+};
+
+const options: RehypeShikiCoreOptions = {
+	themes,
 	// code blocks use wrapping and not scroll overview, so they don't need to be focusable
 	tabindex: false,
 	transformers: [
@@ -28,16 +40,79 @@ const options: RehypeShikiOptions = {
 	],
 };
 
-const shiki: Transformer<Root, Root> = rehypeShiki.call(
-	undefined as never,
-	options,
-)!;
+const highlighter = await createHighlighter({
+	themes: Object.values(themes),
+	langs: [],
+});
+
+type Grammars = Map<string, LanguageRegistration[]>;
+
+const languages: Partial<Record<string, DynamicImportLanguageRegistration>> =
+	bundledLanguages;
+
+// recursively gets embedded languages for the given grammar
+async function collectGrammars(
+	lang: string,
+	seen = new Set<string>(),
+): Promise<Grammars> {
+	const collected: Grammars = new Map();
+	const stack = [lang];
+	// we do this serially since it's fast and there are unfun data races with concurrency
+	for (let next = stack.pop(); next !== undefined; next = stack.pop()) {
+		if (seen.has(next) || isSpecialLang(next)) continue;
+		seen.add(next);
+		const loadGrammars = languages[next];
+		if (!loadGrammars) throw new Error(`Unknown language "${next}"`);
+		// shiki dynamically imports each grammar it needs
+		const grammars = (await loadGrammars()).default;
+		collected.set(next, grammars);
+		const embedded = grammars.flatMap((g) => g.embeddedLangsLazy ?? []);
+		stack.push(...embedded.reverse());
+	}
+	return collected;
+}
+
+// memoizes promises per language to avoid duplication or missing highlights
+const languageLoads = new Map<string, Promise<void>>();
+
+function loadLanguage(lang: string): Promise<void> {
+	let load = languageLoads.get(lang);
+	if (!load) {
+		load = (async () => {
+			const loaded = new Set(highlighter.getLoadedLanguages());
+			const grammars = [...(await collectGrammars(lang))]
+				.filter(([name]) => !loaded.has(name))
+				.flatMap(([, grammars]) => grammars);
+			if (grammars.length) await highlighter.loadLanguage(...grammars);
+		})();
+		languageLoads.set(lang, load);
+	}
+	return load;
+}
+
+// scan for language in language implicit textmate grammar loaded within a codefence to load properly. Eg css in js
+const injecting: LanguageRegistration[] = [];
+const seen = new Set<string>();
+for (const [lang, loadGrammars] of Object.entries(bundledLanguages)) {
+	const grammars = (await loadGrammars()).default;
+	if (grammars.some((grammar) => grammar.injectTo)) {
+		for (const found of (await collectGrammars(lang, seen)).values()) {
+			injecting.push(...found);
+		}
+	}
+}
+await highlighter.loadLanguage(...injecting);
+
+const shiki = rehypeShikiFromHighlighter(highlighter, options);
 
 export default async function transform(node: Element): Promise<Element> {
+	const lang = getCodeLanguage(node);
+	if (lang) await loadLanguage(lang);
+
 	const tree: Root = {
 		type: "root",
 		children: [node],
 	};
-	await shiki(tree, undefined as never, undefined as never);
+	await shiki(tree, new VFile(), () => undefined);
 	return tree.children[0] as Element;
 }


### PR DESCRIPTION
Avoids eager loading/compiling of 350+ dynamic modules per shiki worker thread (4.2s). Loads only what languages that need loaded per thread

I think this goes well with on the fly rendering in target state. In those cases, likely only 1-5 languages will need loaded. Only 60 or so are used in all of PFP

Also throws on invalid grammars instead of silently leaving the block unhighlighted.  All posts are exactly the same beyond those where I fixed the languages 

## benches

I ran this n=2 since it takes a few mins

The build is 2-6s faster wall clock and uses much less CPU time. Each shiki worker would take 4.2s to load, and now takes .5s

| build                | wall        | CPU (user+sys) | peak RSS | route generation |
  |----------------------|-------------|----------------|----------|------------------|
  | 12-core, before (×2) | 1:51        | 375 s          | 9.9 GB   | 96 s             |
  | 12-core, after (×2)  | 1:45 / 1:49 | 283 / 305 s    | 9.1 GB   | 89 / 94 s        |
  | 4-core, before       | 2:06        | 248 s          | 5.1 GB   | 111 s            |
  | 4-core, after        | 2:00        | 225 s          | 5.0 GB   | 105 s            |
  
  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved code syntax highlighting with broader support for dynamically loaded and embedded programming languages.
  - Added more reliable language detection for Markdown code blocks.
- **Bug Fixes**
  - Prevented unsupported or unrecognized languages from causing highlighting failures.
  - Preserved Mermaid code blocks without applying incompatible syntax highlighting.
  - Improved error reporting when a requested language cannot be highlighted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->