### PR TITLE
perf(code-embed): only preload initial file for code embeds

### DIFF
--- a/.storybook/fixtures.ts
+++ b/.storybook/fixtures.ts
@@ -89,17 +89,9 @@ export const snitip = {
 	tagsMeta: new Map(),
 } satisfies SnitipInfo;
 export const entries: FileEntry[] = [
-	{
-		name: "src/main.ts",
-		filetype: "ts",
-		code: 'console.log("Hello, world!");',
-	},
-	{
-		name: "src/styles.css",
-		filetype: "css",
-		code: "body { color: rebeccapurple; }",
-	},
-	{ name: "README.md", filetype: "md", code: "# A small example" },
+	{ name: "src/main.ts", filetype: "ts" },
+	{ name: "src/styles.css", filetype: "css" },
+	{ name: "README.md", filetype: "md" },
 ];
 export const file = {
 	name: "main.ts",

--- a/e2e/tests/code-embed.spec.ts
+++ b/e2e/tests/code-embed.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+let embed: Locator;
+
+test.beforeEach(async ({ page }) => {
+	await page.goto("/posts/ffg-fundamentals-intro-to-components", {
+		waitUntil: "networkidle",
+	});
+	embed = page.locator("astro-island[component-export='CodeEmbed']").first();
+	await embed.scrollIntoViewIfNeeded();
+});
+
+async function selectFile(page: Page, current: string, next: string) {
+	await embed.getByRole("button", { name: current }).first().click();
+	await page
+		.locator("dialog[open]")
+		.getByRole("button", { name: next, exact: true })
+		.click();
+}
+
+test("code embed shows the default file and loads others on demand", async ({
+	page,
+}) => {
+	const code = embed.locator("pre.shiki").first();
+	await expect(code).toContainText("createRoot");
+
+	await selectFile(page, "src/main.jsx", "package.json");
+	await expect(code).toContainText(
+		'"name": "@ffg-fundamentals/react-rendering-1"',
+	);
+
+	await selectFile(page, "package.json", "index.html");
+	await expect(code).toContainText("React Rendering - Example #1");
+});

--- a/src/components/code-embed/code-embed.stories.tsx
+++ b/src/components/code-embed/code-embed.stories.tsx
@@ -18,7 +18,7 @@ function CodeDemo() {
 	return (
 		<CodeContainer file={file} entries={entries} onFileChange={setFile}>
 			<pre>
-				<code>{entries.find((entry) => entry.name === file)?.code}</code>
+				<code>{file}</code>
 			</pre>
 		</CodeContainer>
 	);

--- a/src/components/code-embed/file-picker.stories.tsx
+++ b/src/components/code-embed/file-picker.stories.tsx
@@ -8,7 +8,7 @@ function Demo(args: ComponentProps<typeof FilePicker>) {
 	return (
 		<div style={{ width: "min(600px, 100%)" }}>
 			<FilePicker {...args} file={file} onFileChange={setFile} />
-			<pre>{args.entries.find((entry) => entry.name === file)?.code}</pre>
+			<pre>{file}</pre>
 		</div>
 	);
 }

--- a/src/components/code-embed/types.ts
+++ b/src/components/code-embed/types.ts
@@ -1,5 +1,4 @@
 export interface FileEntry {
 	name: string;
 	filetype: string;
-	code: string;
 }

--- a/src/utils/markdown/components/code-embed/code-embed-content.tsx
+++ b/src/utils/markdown/components/code-embed/code-embed-content.tsx
@@ -2,23 +2,35 @@ import { useEffect, useState } from "preact/hooks";
 import { codeToHtml } from "./code-embed-shiki.ts";
 
 interface CodeEmbedContentProps {
-	code: string;
+	/** Where the file is served from; only fetched when `codeHtml` is absent. */
+	url: string;
 	codeHtml?: string;
 	lang: string;
 }
 
 export function CodeEmbedContent(props: CodeEmbedContentProps) {
-	const [codeHtml, setCodeHtml] = useState<string | undefined>(undefined);
+	const [code, setCode] = useState<string>();
+	const [codeHtml, setCodeHtml] = useState<string>();
 
 	useEffect(() => {
-		// If codeHtml is provided from SSR, do nothing
+		// The initially selected file is rendered on the server as codeHtml
 		if (props.codeHtml) return;
 
+		let stale = false;
+		setCode(undefined);
 		setCodeHtml(undefined);
-		if (props.code.length < 10_000) {
-			codeToHtml(props.code, props.lang).then((html) => setCodeHtml(html));
-		}
-	}, [props.code, props.lang, props.codeHtml]);
+		fetch(props.url)
+			.then((response) => response.text())
+			.then(async (text) => {
+				if (stale) return;
+				setCode(text);
+				if (text.length < 10_000)
+					setCodeHtml(await codeToHtml(text, props.lang));
+			});
+		return () => {
+			stale = true;
+		};
+	}, [props.url, props.lang, props.codeHtml]);
 
 	const codeHtmlToDisplay = props.codeHtml ?? codeHtml;
 
@@ -28,7 +40,7 @@ export function CodeEmbedContent(props: CodeEmbedContentProps) {
 	return (
 		<div>
 			<pre class="shiki">
-				<code>{props.code}</code>
+				<code>{code}</code>
 			</pre>
 		</div>
 	);

--- a/src/utils/markdown/components/code-embed/code-embed-content.tsx
+++ b/src/utils/markdown/components/code-embed/code-embed-content.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from "preact/hooks";
 import { codeToHtml } from "./code-embed-shiki.ts";
 
 interface CodeEmbedContentProps {
-	/** Where the file is served from; only fetched when `codeHtml` is absent. */
 	url: string;
 	codeHtml?: string;
 	lang: string;
@@ -13,7 +12,7 @@ export function CodeEmbedContent(props: CodeEmbedContentProps) {
 	const [codeHtml, setCodeHtml] = useState<string>();
 
 	useEffect(() => {
-		// The initially selected file is rendered on the server as codeHtml
+		// If codeHtml is provided from SSR, do nothing
 		if (props.codeHtml) return;
 
 		let stale = false;

--- a/src/utils/markdown/components/code-embed/code-embed.tsx
+++ b/src/utils/markdown/components/code-embed/code-embed.tsx
@@ -36,6 +36,7 @@ function shortenProcessUrl(url: string): string {
 export interface CodeEmbedProps {
 	projectId: string;
 	projectZipUrl: string;
+	projectUrl: string;
 	title: string;
 	file?: string;
 	fileHtml?: string;
@@ -84,7 +85,7 @@ export function CodeEmbed(props: CodeEmbedProps) {
 	}, []);
 
 	const [selectedFile, setSelectedFile] = useState(props.file);
-	const selectedFileContent = props.files.find(
+	const selectedFileEntry = props.files.find(
 		(file) => file.name == selectedFile,
 	);
 
@@ -98,10 +99,10 @@ export function CodeEmbed(props: CodeEmbedProps) {
 					file={selectedFile}
 					onFileChange={setSelectedFile}
 				>
-					{selectedFileContent ? (
+					{selectedFileEntry ? (
 						<CodeEmbedContent
-							code={selectedFileContent.code}
-							lang={selectedFileContent.filetype}
+							url={`${props.projectUrl}/${selectedFileEntry.name}`}
+							lang={selectedFileEntry.filetype}
 							codeHtml={selectedFile == props.file ? props.fileHtml : undefined}
 						/>
 					) : (

--- a/src/utils/markdown/components/code-embed/rehype-transform.ts
+++ b/src/utils/markdown/components/code-embed/rehype-transform.ts
@@ -82,13 +82,9 @@ export const transformCodeEmbed: RehypeFunctionComponent = async (props) => {
 	})) {
 		if (file.isFile()) {
 			const parent = path.relative(projectDir, file.parentPath);
-			const name = path.join(parent, file.name);
-			const code = await fs.readFile(path.join(projectDir, name), "utf-8");
-
 			files.push({
 				name: path.join(parent, file.name),
 				filetype: path.extname(file.name).substring(1),
-				code,
 			});
 		}
 	}
@@ -106,13 +102,18 @@ export const transformCodeEmbed: RehypeFunctionComponent = async (props) => {
 	const file = selectedFiles.at(0);
 	const fileEntry = files.find((entry) => entry.name == file);
 	const fileHtml = fileEntry
-		? await codeToHtml(fileEntry.code, fileEntry.filetype)
+		? await codeToHtml(
+				await fs.readFile(path.join(projectDir, fileEntry.name), "utf-8"),
+				fileEntry.filetype,
+			)
 		: undefined;
 
 	return [
 		createComponent("CodeEmbed", {
 			projectId: project,
 			projectZipUrl: `/generated/projects/${post}_${project}.zip`,
+			// project files are served statically from the content directory
+			projectUrl: `/${path.relative(process.cwd(), projectDir)}`,
 			title: props.attributes.title,
 			file,
 			fileHtml,

--- a/src/utils/markdown/components/code-embed/rehype-transform.ts
+++ b/src/utils/markdown/components/code-embed/rehype-transform.ts
@@ -112,7 +112,6 @@ export const transformCodeEmbed: RehypeFunctionComponent = async (props) => {
 		createComponent("CodeEmbed", {
 			projectId: project,
 			projectZipUrl: `/generated/projects/${post}_${project}.zip`,
-			// project files are served statically from the content directory
 			projectUrl: `/${path.relative(process.cwd(), projectDir)}`,
 			title: props.attributes.title,
 			file,


### PR DESCRIPTION
Migrate to fetching static files already in the server instead, pretender only initial file. Lowers initial page sizes and lowers build time by 10 seconds

Code embeds inlined full text in the HTML instead of querying. Web containers continue to query a zip file

The preview environment works fine, is it safe to assume production has the same nginx rules?

## uncompressed page sizes before interactions

The minimum bound is now lowered, if a user clicks every single file, it will be at most the same. Note that these compress well since they have lots of repeated files. The browser cache can now dedupe same files 

| page                                    | before  | after   |
|-----------------------------------------|---------|---------|
| ffg-fundamentals-side-effects           | 13.8 MB | 3.0 MB  |
| ffg-fundamentals-intro-to-components    | 11.6 MB | 2.5 MB |
| ffg-fundamentals-dependency-injection   | 10.0 MB | 2.1 MB  |
| post pages over 2 MB                    | 49      | 10      |

## benchmarks

Saves 10 seconds wall clock time. I believe this is faster due to IO and avoiding serializing props

| build         | wall | CPU (user+sys) | route generation |
|---------------|------|----------------|------------------|
| main          | 1:51 | 375 s          | 96 s             |
| this branch   | 1:41 | 367 s          | 87 s             |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Code embeds now load and display source files dynamically from the configured project location.
  - Selecting a file displays its filename while the corresponding content is loaded for viewing.
  - Small source files receive syntax highlighting when displayed.

- **Bug Fixes**
  - Improved code loading behavior to prevent outdated file content from appearing during selection changes.

- **Tests**
  - Added end-to-end coverage for viewing and switching between files in code embeds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->