### PR TITLE
perf(api): parse each published date once when sorting posts

### DIFF
--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -29,8 +29,22 @@ function findLocalizedEntry<T extends { locale: Locale }>(
 	);
 }
 
+// without cache, date objects are constructed thousands of times, taking several seconds
+const timestamps = new Map<string, number>();
+
+function toTimestamp(date: string): number {
+	const cached = timestamps.get(date);
+	if (cached !== undefined) {
+		return cached;
+	}
+
+	const timestamp = new Date(date).getTime();
+	timestamps.set(date, timestamp);
+	return timestamp;
+}
+
 function compareByDate(date1: string, date2: string): number {
-	return new Date(date1) > new Date(date2) ? -1 : 1;
+	return toTimestamp(date1) > toTimestamp(date2) ? -1 : 1;
 }
 
 function compareByPublished<T extends { published: string }>(


### PR DESCRIPTION
Centralizes post sorting. Originally this PR memorized 30M calls, but this moves it out of the front matter to avoid parsing per page load, so only 929 parse calls happen instead of n^2logn

Also makes post ordering deterministic (which is more valuable than the one second saved IMO)

Saves around a second

| | main | this branch |
|---|---|---|
| total wall | 87.4 s | 86.6 s |
| CPU (user+sys) | 233.8 s | 233.4 s |
| full-list sorts per build | ~2,000 | 1 per locale |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved caching for localized posts and collections, helping repeated filtering and sorting requests return more efficiently.
* **Consistency**
  * Standardized how localized content is read and cached across posts and collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->