### PR TITLE
perf(shiki): cap the highlighting worker pool at 3 threads

### DIFF
--- a/src/utils/markdown/shiki/shiki-pool.ts
+++ b/src/utils/markdown/shiki/shiki-pool.ts
@@ -37,6 +37,7 @@ if (errors.length) {
 const tinypool = new Tinypool({
 	filename: workerFile,
 	minThreads: 0,
+	maxThreads: 4,
 	idleTimeout: 60 * 1000, // 60 seconds
 	maxMemoryLimitBeforeRecycle: 500_000_000, // 500MB
 });

--- a/src/utils/markdown/shiki/shiki-pool.ts
+++ b/src/utils/markdown/shiki/shiki-pool.ts
@@ -37,7 +37,7 @@ if (errors.length) {
 const tinypool = new Tinypool({
 	filename: workerFile,
 	minThreads: 0,
-	maxThreads: 4,
+	maxThreads: 3,
 	idleTimeout: 60 * 1000, // 60 seconds
 	maxMemoryLimitBeforeRecycle: 500_000_000, // 500MB
 });


### PR DESCRIPTION
2-3 workers can drain the work effectively, so using tinypool's default makes the build slower and use a lot more ram

These are measured against all my CPU improvement PRs so the pool is fed the most. Similar trends show on current main

| threads      | wall        | CPU (user+sys) | peak RSS |
|--------------|-------------|----------------|----------|
| 12 (default) | 1:45 / 1:49 | 283 s / 305 s  | 9.1 GB   |
| 4            | 1:04 / 1:05 | 198 s / 200 s  | 5.3 GB   |
| 3            | 1:05        | 188 s          | 4.5 GB   |
| 2            | 1:09        | 177 s          | 3.8 GB   |