### PR TITLE
Snitip styling fixes

### DIFF
--- a/src/components/snitip/snitip.module.scss
+++ b/src/components/snitip/snitip.module.scss
@@ -52,8 +52,8 @@
 
 .closeButton {
 	position: absolute;
-	top: var(--snitip_close-btn_margin);
-	right: var(--snitip_close-btn_margin);
+	top: calc(var(--snitip_border-width) + var(--snitip_close-btn_margin));
+	right: calc(var(--snitip_border-width) + var(--snitip_close-btn_margin));
 	z-index: 1;
 }
 

--- a/src/views/search/search-page.module.scss
+++ b/src/views/search/search-page.module.scss
@@ -43,7 +43,7 @@
 }
 
 .snitipsContainer {
-	padding-top: var(--site-spacing);
+	margin-bottom: var(--site-spacing);
 }
 
 .collectionsGrid {


### PR DESCRIPTION

#### Snitip dialog - close button margin

The button margin used absolute positioning via `top`/`left`, but did not account for the border width. The margin should be `spc-2x` between the edge of the button and the border.

| Before | After |
|---|---|
| <img width="784" height="428" alt="Screenshot from 2026-09-13 07-51-07" src="https://github.com/user-attachments/assets/f1fcb2a3-a273-48b7-a5c8-c7073425742b" /> | <img width="784" height="428" alt="Screenshot from 2026-09-13 07-50-38" src="https://github.com/user-attachments/assets/2f4e7901-c8ec-4e71-81af-fc558f98483a" /> |

#### Search page - snitip card section spacing

`.snitipsContainer` used `padding-top` unnecessarily (the results count already defines a margin), and did not have any bottom spacing between the itself and the post/collection grid.

| Before | After |
|---|---|
| <img width="1782" height="1119" alt="Screenshot from 2026-09-13 07-54-16" src="https://github.com/user-attachments/assets/572b91e2-2332-4361-91c0-fadf1e018ce4" /> | <img width="1782" height="1119" alt="Screenshot from 2026-09-13 07-55-10" src="https://github.com/user-attachments/assets/e90de7ca-eafd-4d20-84bb-7e010afa52b4" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved close-button positioning so it remains clear of modal borders.
  * Adjusted search page spacing to provide consistent separation below snitips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->